### PR TITLE
Updating Ergo Docs Page Readme/ some pages to remove error 404 links. Small Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ergo Platform documentation
 =======================================
 
-[docs.ergoplatform.org](https://docs.ergoplatform.com/)
+[docs.ergoplatform.com](https://docs.ergoplatform.com/)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Ergo Platform documentation
 =======================================
 
-[docs.ergoplatform.org](https://docs.ergoplatform.org)
+[docs.ergoplatform.org](https://docs.ergoplatform.com/)
 
 ## Contributing
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -4,10 +4,10 @@
 ## Getting Started
 
 - Ergo is currently available on the following [wallets](https://ergoplatform.org/en/wallets/) and [exchanges](https://ergoplatform.org/en/exchanges/). 
-- The development roadmap can be seen [here](https://ergonaut.space/en/roadmap).
+- The development roadmap can be seen [here](https://ergoplatform.org/en/ecosystem/#Roadmap).
 - To see the applications currently running on Ergo, check out [sigmaverse.io](https://sigmaverse.io/).
 - To read about Ergo from a less technical perspective, visit [ergonaut.space](https://ergonaut.space/en/home). 
-- If you want to mine, see the [Miners Handbook](https://ergonaut.space/Mining).
+- If you want to mine, see the [Miners Handbook](https://ergonaut.space/en/Guides/Mining).
 
 ## Why '*Ergo*'? 
 

--- a/docs/node/install/pi.md
+++ b/docs/node/install/pi.md
@@ -9,7 +9,7 @@ curl -s https://raw.githubusercontent.com/ergoplatform/ergo/master/ergo-installe
 
 With this script you'll have the latest Ergo node installed without any hassle.
 
-If you'd prefer to get set up manually, here's a [step-by-step.](https://ergoplatform.org/en/blog/2019_12_02_how_to_setup/). 
+If you'd prefer to get set up manually, here's a [step-by-step.](https://ergoplatform.org/en/blog/2019_12_02_how_to_setup/) 
 
 ## Light Mode
 ```conf

--- a/docs/node/install/pi.md
+++ b/docs/node/install/pi.md
@@ -9,7 +9,7 @@ curl -s https://raw.githubusercontent.com/ergoplatform/ergo/master/ergo-installe
 
 With this script you'll have the latest Ergo node installed without any hassle.
 
-If you'd prefer to get set up manually, here's a [step-by-step.](https://ergoplatform.org/en/blog/2019_12_02_how_to_setup/) 
+If you'd prefer to get set up manually, here's a [step-by-step.](https://ergoplatform.org/en/blog/2019_12_02_how_to_setup/).
 
 ## Light Mode
 ```conf
@@ -57,4 +57,4 @@ scorex {
 
 ### Resources
 
-- [How to setup an Ergo Node on a Raspberry Pi](https://youtu.be/yDqhlgz0244)
+- [How to setup an Ergo Node on a Raspberry Pi](https://youtu.be/yDqhlgz0244).

--- a/docs/node/install/pi.md
+++ b/docs/node/install/pi.md
@@ -9,7 +9,7 @@ curl -s https://raw.githubusercontent.com/ergoplatform/ergo/master/ergo-installe
 
 With this script you'll have the latest Ergo node installed without any hassle.
 
-If you'd prefer to get set up manually, here's a [step-by-step.](/node/platforms/tutorial).
+If you'd prefer to get set up manually, here's a [step-by-step.](https://ergoplatform.org/en/blog/2019_12_02_how_to_setup/). 
 
 ## Light Mode
 ```conf

--- a/docs/node/install/pi.md
+++ b/docs/node/install/pi.md
@@ -1,5 +1,6 @@
-## How to set up and configure a full Ergo node
+# How to set up and configure a full Ergo node
 
+## Quick Start
 
 You can run [ergo-installer.sh](https://github.com/ergoplatform/ergo/blob/master/ergo-installer.sh)
 
@@ -9,7 +10,42 @@ curl -s https://raw.githubusercontent.com/ergoplatform/ergo/master/ergo-installe
 
 With this script you'll have the latest Ergo node installed without any hassle.
 
-If you'd prefer to get set up manually, here's a [step-by-step.](https://ergoplatform.org/en/blog/2019_12_02_how_to_setup/).
+If you'd prefer to get set up manually, here's a [step-by-step guide](https://github.com/ergoplatform/ergo/wiki/Set-up-a-full-node).
+
+## Optimization
+
+The Raspberry Pi is a very powerful device but it has hardware limitations which prevent it from syncing a full Ergo node quickly and efficiently. Below are a few things you can do to ensure a smooth setup process.
+
+> Note: This was written as of Ergo node release 4.0.27 and tested on multiple Pi4 with 4gb RAM
+
+### Memory
+
+If you are booting from a microSD card then it is definintely worth paying a little more for the extra headroom. 
+
+* 32gb: completed node sync in 4.5 days
+* 256gb: completed node sync in 40 hours
+
+### SWAP Size
+
+Increase the system's total accessible memory beyond its hardware capabilities. 
+
+```bash
+sudo dphys-swapfile swapoff
+sudo nano /etc/dphys-swapfile
+CONF_SWAPSIZE=4096 
+sudo dphys-swapfile setup
+sudo dphys-swapfile swapon
+sudo reboot now
+```
+
+### Limit Heap
+
+When ready to launch the node we want to set a maximum limit of 2gb.
+
+```bash
+java -Xmx2g -jar ergo-<release-version>.jar --mainnet -c ergo.conf
+```
+
 
 ## Light Mode
 ```conf
@@ -55,6 +91,8 @@ scorex {
 ```
 
 
-### Resources
+## Resources
 
-- [How to setup an Ergo Node on a Raspberry Pi](https://youtu.be/yDqhlgz0244).
+- [How to setup an Ergo Node on a Raspberry Pi](https://youtu.be/yDqhlgz0244)
+
+


### PR DESCRIPTION
Hi, I edited the mark down for the read me to change the link to reflect the actual link so that people don't encounter the error 502 as per  issue #6. 

- I also updated the links that were throwing error 404 in order to reflect the proper links. 

That is all for my small patch to the ergo github doc page. I will make more updates if I notice anything else or feel there should be more information to add.  If there is any questions you may have feel free to reply. 