### PR TITLE
Reorganize navigation and add audience hubs

### DIFF
--- a/docs/hubs/index.md
+++ b/docs/hubs/index.md
@@ -1,0 +1,10 @@
+---
+title: Audience Hubs
+---
+# Audience Hubs
+- **Learn Ergo** → index, Why Ergo, misconceptions, events, FAQ
+- **Build on Ergo** → quick start, tutorials, SDKs, APIs, data model, transactions
+- **Run Nodes & Mine** → node install, modes, testnet, pools, config
+- **Using Ergo** → wallets, addresses, payments, ecosystem apps, use cases
+- **Join & Govern** → EF, DevDAO, programs, contributions, standards, guidelines
+- **Protocol & Research** → protocol, eUTxO, NIPoPoWs, Autolykos, ZK, cryptography

--- a/docs/site-map.md
+++ b/docs/site-map.md
@@ -1,0 +1,5 @@
+---
+title: Site Map
+---
+# Site Map
+<pagetree />

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,10 +25,11 @@ theme:
         - content.code.copy
         - navigation.tabs
         # - navigation.instant
-        # - navigation.sections # The bold sections in navigation
+        - navigation.sections
         - navigation.tracking
         - navigation.indexes
         - content.tabs.link
+        - navigation.footer
         - toc.follow
 
       #  - toc.integrate
@@ -74,12 +75,22 @@ plugins:
   #- awesome-nav #https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin
   - autolinks
   - tags: # https://squidfunk.github.io/mkdocs-material/setup/setting-up-tags/#
+  - breadcrumbs
+  - pagetree
+  - redirects
   #- bibtex:
   #    bib_file: refs.bib
   #- categories
   #- exclude-search # https://github.com/chrieke/mkdocs-exclude-search
   #- semiliterate # http://studioinfinity.org/semiliterate/mkdocs_semiliterate/plugin/
   #- pagenav-generator #https://github.com/Andre601/mkdocs-pagenav-generator
+
+
+validation:
+  links:
+    absolute_links: relative_to_docs
+    anchors: warn
+    unrecognized_links: warn
 
 
 
@@ -130,20 +141,10 @@ markdown_extensions:
 
 
 nav:
-  - Overview:
+  - Learn Ergo:
       - Welcome: index.md
       - Why Ergo: dev/protocol/why.md
       - Common Misconceptions: fud-faq.md
-      - Governance & Community:
-          - Ergo Foundation:
-              - ef/ergo-foundation.md
-              - Scope: ef/ef-scope.md
-              - Treasury: ef/ef-treasury.md
-              - Votes: ef/ef-votes.md
-              - Future: ef/ef-future.md
-          - DevDao: devdao.md
-          - Sigmanauts: contribute/sigmanauts.md
-          - Partnerships: partners.md
       - Compliance & Legal:
           - Social Contract: social_contract.md
           - Audit: dev/protocol/audit.md
@@ -155,85 +156,14 @@ nav:
       - Reference:
           - Glossary: glossary.md
           - FAQ: faq.md
-  - Protocol & Research:
-      - Core Concepts:
-          - Protocol Overview: dev/protocol/protocol-overview.md
-          - eUTxO:
-              - dev/protocol/eutxo.md
-              - UTxO vs Account: dev/protocol/eutxo/accountveutxo.md
-              - Atomic Swaps: dev/protocol/eutxo/atomic.md
-              - Ergo vs Cardano: dev/protocol/eutxo/ergo_vs_cardano.md
-              - UTXO State: dev/protocol/eutxo/utxo-state.md
-          - NIPoPoWs:
-              - dev/protocol/nipopows.md
-              - Light Clients: dev/protocol/nipopow/nipopow_nodes.md
-              - Light Miners: dev/protocol/nipopow/logspace.md
-              - Sidechains: dev/protocol/nipopow/nipopow-sidechains.md
-          - Privacy:
-              - dev/protocol/zkp.md
-              - Privacy Guide: doc/privacy-guide.md
-          - Storage Rent: dev/protocol/storage-rent.md
-          - Autolykos: dev/protocol/autolykos-protocol.md
-      - Research Library:
-          - documents.md
-          - Whitepaper: doc/whitepaper.md
-          - ErgoScript Whitepaper: doc/ergoscript-whitepaper.md
-          - On Contractual Money: doc/on-contractual-money.md
-      - Roadmap & Scaling:
-          - Roadmap Overview: roadmap.md
-          - Scaling Overview: dev/protocol/scaling.md
-          - Layer 0:
-              - dev/protocol/scaling/layer0.md
-              - Sub Blocks:
-                  - uses/sidechains/subblocks.md
-                  - Technical Details: uses/sidechains/input-blocks.md
-          - Layer 1: dev/protocol/scaling/layer1.md
-          - Layer 2: dev/protocol/scaling/layer2.md
-          - Discussions:
-              - Roadmaps: dev/protocol/scaling/scaling-roadmap.md
-              - Transactions Per Second: dev/protocol/scaling/TPS.md
-              - Atomic Composability: dev/protocol/scaling/atomic-composability.md
-      - Cryptography & Data Structures:
-          - Cryptography Overview: crypto.md
-          - Sigma Protocols:
-              - dev/scs/sigma.md
-              - Schnorr:
-                  - dev/scs/sigma/schnorr.md
-                  - Verifying Schnorr Signatures: dev/scs/sigma/verifying.md
-              - Diffie-Hellman: dev/scs/sigma/diffie.md
-              - Other Signatures:
-                  - Ring Signatures: dev/data-model/ring.md
-                  - Threshold Signatures: dev/data-model/threshold.md
-                  - 3-out-of-5 Threshold Signature: dev/scs/sigma/3-out-of-5.md
-                  - Distributed Signatures: node/sigs.md
-                  - Signature Scheme Internals: sig-scheme.md
-                  - Improved Signatures: dev/scs/sigma/improved-signatures.md
-          - Zero-Knowledge Proofs:
-              - Non-Interactive ZK: dev/data-model/nizk.md
-              - ZeroJoin: dev/crypto/zerojoin.md
-          - Data Structures:
-              - Overview: dev/data-model/data-structures.md
-              - Merkle Trees:
-                  - dev/data-model/structures/merkle/merkle-tree.md
-                  - Format: dev/data-model/structures/merkle/merkle-format.md
-                  - Validation: dev/data-model/structures/merkle/merkle-validation.md
-                  - Considerations: dev/data-model/structures/merkle/merkle-considerations.md
-                  - Extension Block Merkle: dev/data-model/structures/merkle/merkle-extension.md
-                  - Transaction Merkle Trees: dev/protocol/tx/tx-merkle.md
-                  - Merkle Batch Proofs: dev/data-model/structures/merkle/merkle-batch-proof.md
-                  - Batch Implementation: dev/data-model/structures/merkle/merkle-batch-impl.md
-                  - Batch Testing: dev/data-model/structures/merkle/merkle-batch-testing.md
-                  - Lightweight Client Proofs: dev/data-model/structures/merkle/merkle-light-proof.md
-              - AVL Trees: dev/protocol/avl.md
-              - Plasma Library: dev/lib/plasma.md
-              - Proof-of-Proof-of-Work: dev/data-model/structures/popow.md
-              - Interlink Vectors: dev/data-model/structures/interlink-vectors.md
+          - Site Map: site-map.md
+      - Audience Hubs: hubs/index.md
   - Build on Ergo:
       - Start Building:
           - Quick Start: dev/get-started.md
           - Developer Resources: dev/start/resources.md
           - Students: students/index.md
-      - Tutorials & Recipes:
+      - Follow Tutorials & Recipes:
           - Overview: dev/tutorials.md
           - Fleet SDK Recipes: dev/tutorials/fleet-sdk-recipes.md
           - Blockchain Indexing:
@@ -247,7 +177,7 @@ nav:
           - Token Integration Guides: tutorials/token_integration.md
           - rsERG-LP Tutorial: tutorials/rsERGLP.md
           - Access Issues Troubleshooting: tutorials/access-issues.md
-      - Data Model & Transactions:
+      - Model Data & Build Transactions:
           - Data Model Overview: dev/data-model/data-model.md
           - Box Model:
               - dev/data-model/box.md
@@ -349,7 +279,7 @@ nav:
               - Headless dApp Framework:
                   - Overview: dev/stack/headless.md
                   - Modules: dev/stack/headless/modules.md
-          - Tooling & Debugging:
+          - Debug & Test:
               - ErgoScript Tooling: dev/scs/ergoscript-tooling.md
               - Interpreters & Compilers: dev/stack/interpreters.md
               - Compiler Phases: dev/scs/ergoscript/compiler-phases.md
@@ -375,7 +305,7 @@ nav:
               - EIP12 Types: dev/lib/eip12-types.md
               - SigmaJS: dev/lib/sigmajs.md
               - DeCo: dev/deco.md
-      - APIs & Services:
+      - Use APIs & Services:
           - Explorer & Indexing:
               - Explorer Overview: dev/stack/explorer.md
               - Local Setup: dev/stack/explorer/explorer_local.md
@@ -390,7 +320,7 @@ nav:
               - Off-Chain Bots: dev/oc/dex_bots.md
               - Rust Utilities: dev/oc/ergo_utilities.md
               - Plasma Overview: dev/lib/plasma.md
-  - Run the Network:
+  - Run Nodes & Mine:
       - Interaction Overview: dev/interact.md
       - Node Operations:
           - Node Overview: node/install.md
@@ -459,218 +389,8 @@ nav:
           - OpenAPI Spec: node/swagger/openapi.md
           - Try it out!: node/swagger/swagger_api.md
           - Indexed Node API: node/indexed-node.md
-  - Wallets & Payments:
-      - Wallet Overview: dev/wallets.md
-      - Addresses & Keys:
-          - Address Overview: dev/wallet/address.md
-          - Address Types: dev/wallet/address/address_types.md
-          - Address Validation: dev/wallet/address/address_validation.md
-          - Wallet Keys: dev/wallet/keys.md
-      - Wallet Guides:
-          - Wallet Setup: node/wallet-setup.md
-          - Satergo: dev/wallet/satergo.md
-          - Nautilus: dev/wallet/nautilus.md
-          - Minotaur: dev/wallet/minotaur.md
-          - Minotaur Multi-Sig: dev/wallet/minotaur-multisig.md
-          - SAFEW: dev/wallet/safew.md
-          - Ledger: dev/wallet/payments/ledger.md
-          - Paper Wallet: dev/wallet/paper-wallet.md
-          - Satergo Vault: dev/wallet/satergo-vault.md
-      - Payments & Authentication:
-          - ErgoPay Overview: dev/wallet/payments/ergopay/ergo-pay.md
-          - ErgoPay Tutorial: dev/wallet/payments/ergopay/ep-tutorial.md
-          - ErgoAuth: dev/wallet/payments/ergoauth.md
-          - dApp Connector: dev/wallet/payments/dApp.md
-          - Proxy Contracts: dev/wallet/payments/proxy.md
-          - Assembler: dev/stack/assembler.md
-      - Standards & Integration:
-          - MultiSig: dev/wallet/multisig.md
-          - UTXO-Set Scanning Wallet API: dev/wallet/standards/eip1.md
-          - Deterministic Wallet Standard: dev/wallet/standards/eip3.md
-          - Cold Wallet Standard: dev/wallet/standards/eip19.md
-          - EIP Standards Overview: dev/wallet/eip-standards.md
-          - EIP-0005: dev/wallet/standards/eip5.md
-          - Integration Guide: dev/Integration/guide.md
-          - Transaction Lifecycle: dev/integration/transaction-lifecycle.md
-          - Dust Collection: dev/integration/dust-collection.md
-  - Ecosystem & Use Cases:
-      - Overview: uses/use-cases-overview.md
-      - Bridges & Infrastructure:
-          - Artificial Intelligence: ai.md
-          - Rosen Bridge:
-              - eco/rosen.md
-              - Watchers:
-                  - eco/rosen/watcher.md
-                  - Prerequisites: eco/rosen/rosen-preq.md
-                  - Ergo Watcher: eco/rosen/ergo-watcher.md
-                  - Bitcoin Watcher: eco/rosen/bitcoin-watcher.md
-              - Guards: eco/rosen/rosen-guard.md
-              - Tokenomics: eco/rosen/rosen-tokenomics.md
-              - Team: eco/rosen/rosen-team.md
-              - Uses:
-                  - eco/rosen/rosen-uses.md
-                  - rsERG-LP: tutorials/rsERGLP.md
-                  - Token Integration Guides: tutorials/token_integration.md
-          - Oracles:
-              - uses/oracles.md
-              - Oracle Pools V2: eco/oracles-v2.md
-              - Mixicles: uses/mixicles.md
-          - Sidechains:
-              - uses/sidechains.md
-              - Sub Blocks: uses/sidechains/subblocks.md
-              - Sigma Chains: uses/sidechains/sigma-chains.md
-              - PoUW: uses/pouw.md
-      - Finance & Markets:
-          - Decentralized Exchanges:
-              - uses/dex.md
-              - ErgoDex: eco/spectrum.md
-              - Trade House: eco/ergo-auctions.md
-              - Palmyra: eco/palmyra.md
-              - Crystal Pool: eco/crystal-pool.md
-              - Machina Finance: eco/machina-finance.md
-              - Mew Finance: eco/mew-finance.md
-              - P2P Trading: eco/p2p-trading.md
-              - Token Jay: eco/token-jay.md
-              - Single Tx Swap: eco/single-tx-swap.md
-          - Monetary Systems:
-              - SigmaUSD: uses/sigmausd.md
-              - ChainCash: uses/chaincash.md
-              - Gluon: eco/gluon.md
-              - DexyGold: eco/dexy.md
-              - Local Exchange Trading Systems:
-                  - uses/lets.md
-                  - Basic Implementation: uses/lets/basic-imp.md
-                  - Trustless LETS: uses/lets/trustless-lets.md
-          - Decentralized Finance:
-              - Lending Overview: uses/lending.md
-              - duckpools: eco/duckpools.md
-              - EXLE: eco/exle.md
-              - SigmaFi: eco/sigmafi.md
-              - Derivatives and Synthetics:
-                  - uses/deriv.md
-                  - Hodlbox: eco/hodlbox.md
-                  - HodlCoin: eco/hodlcoin.md
-                  - AuctionCoin: eco/auction-coin.md
-                  - OptionCoin: eco/optioncoin.md
-                  - OptionPools: eco/optionPools.md
-                  - SigmaO: eco/sigmao.md
-              - Crowdfunding:
-                  - uses/crowdfunding.md
-                  - ErgoRaffle: eco/ergoraffle.md
-                  - Sigma Subscriptions: eco/sigma-subscriptions.md
-          - Degenerate Finance:
-              - uses/degfi.md
-              - Grand Gambit: eco/grand-gambit.md
-              - Obolflip: eco/obolflip.md
-              - Lotteries: uses/lottery.md
-              - The Field: eco/the-field.md
-      - NFTs & Gaming:
-          - NFTs Overview: uses/nft.md
-          - ErgoAuctionHouse: eco/ergo-auctions.md
-          - SkyHarbor: eco/skyharbor.md
-          - Lilium: eco/lilium.md
-          - Gaming Overview: uses/gaming.md
-          - BlitzTCG: eco/blitz.md
-          - Cyberverse: eco/cyberverse.md
-      - Applications & Utilities:
-          - Crux Finance: eco/crux.md
-          - ErgoNames: eco/ergonames.md
-          - Celaut:
-              - eco/celaut.md
-              - Reputation System: eco/reputation-system.md
-          - Netnotes: eco/netnotes.md
-          - SigmaRand: eco/sigmarand.md
-          - Moria Finance: eco/moria-finance.md
-          - Trading Tools:
-              - Arbit: uses/arbit.md
-              - Grid Trading: uses/grid_trading.md
-              - Off the Grid: uses/off_the_grid.md
-              - Off the Grid Tutorial: uses/off_the_grid_tut.md
-          - Applications:
-              - TabbyPOS: eco/tabbypos.md
-              - PandaV: eco/pandav.md
-              - ZenGate Global:
-                  - eco/zengate.md
-                  - Solaris Portal: eco/solaris.md
-                  - Cyberiad: eco/cyberaid.md
-      - Privacy Solutions:
-          - Mixing Overview: uses/mixer.md
-          - ErgoMixer:
-              - eco/ergomixer.md
-              - Identifiability: eco/ergomixer/identifiability.md
-              - Best Practices: eco/ergomixer/best-practices.md
-              - FAQ: eco/ergomixer/mixer-faq.md
-              - Token: eco/ergomixer/token.md
-              - Install on Android: eco/ergomixer/mixer-android.md
-          - SigmaJoin: eco/sigmajoin.md
-          - Stealth Addresses: uses/stealth-address.md
-          - ZK Treasury: uses/zkt.md
-          - Decentralised Anon ID: eco/ergonation.md
-      - DAO & Governance Apps:
-          - uses/dao.md
-          - Paideia: eco/paideia.md
-          - The Field DAO: eco/the-field.md
-      - Mining Ecosystem:
-          - eco/miner-tooling.md
-          - Lithos: eco/lithos.md
-          - GuapSwap: eco/guapswap.md
-          - CYTI: eco/cyti.md
-      - Further Ideas & Research:
-          - Profit Sharing: uses/profit.md
-          - Email Client for Blocked Internet: uses/blocked_web.md
-          - Flash Loans: uses/flash-loans.md
-          - Prediction Markets: uses/prediction_markets.md
-          - Insurance: uses/insurance.md
-          - Micro Credit: dev/scs/microcredit.md
-          - Mutual Credit: uses/mutual_credit.md
-          - Bonding Curve: uses/bonding.md
-          - Token Concepts:
-              - ICOs: uses/ergo-ico.md
-              - Index Coins: uses/index_coins.md
-              - PoW Tokens: uses/PoW_tokens.md
-              - Perpetual Tokens: dev/tokens/perpetual.md
-              - Buy Back Guarantees: uses/dex-buyback.md
-  - Participate & Contribute:
-      - Get Involved:
-          - Overview: contribute.md
-          - Sigmanauts Program: contribute/sigmanauts.md
-          - Marketing: contribute/marketing.md
-      - Developer Contributions:
-          - Overview: contribute/devs.md
-          - Technical Guidelines: contribute/technical-guidelines.md
-          - Roles: contribute/roles.md
-          - Contribute to the Docs!: contribute/docs.md
-      - Funding & Support:
-          - Bounties: contribute/bounties.md
-          - Grants: contribute/grants.md
-      - Standards & Best Practices:
-          - Overview: contribute/standards.md
-          - Chat Bridge: contribute/standards/chat-bridge.md
-          - ErgoTipperBot: contribute/standards/tipbot.md
-          - KYA: contribute/standards/kya.md
-          - Community Guidelines: contribute/standards/guidelines.md
-          - Moderation Guide: contribute/standards/moderation.md
-          - Analytics: contribute/standards/analytics.md
-  - Mining & Proof of Work:
-      - Autolykos Overview: mining/autolykos.md
-      - Algorithm Details:
-          - Emission: mining/emission.md
-          - EFYT: efyt.md
-          - Difficulty Adjustment: mining/difficulty.md
-          - Solution Verification: mining/solution-verification.md
-          - Technical Breakdown: mining/algo-technical.md
-      - Storage Rent:
-          - Overview: mining/rent.md
-          - Fees: mining/rent/rent-fees.md
-          - Tokens: mining/rent/rent-tokens.md
-          - Spending: mining/rent/rent-spending.md
-          - State Growth: mining/rent/rent-paper.md
-      - ASIC Resistance: mining/asic.md
       - Mining Resources: mining/mining-resources.md
       - CPU vs GPU: mining/cpu.md
-      - EIPs:
-          - Emission Retargeting Soft-Fork: mining/standards/eip27.md
-          - Tweaking Difficulty Adjustment Algorithm: mining/standards/eip37.md
       - Getting Started:
           - Mining Overview: mining/mining-overview.md
           - Join a Pool: mining/setup/join.md
@@ -687,14 +407,6 @@ nav:
           - Stratum: mining/setup/stratum.md
           - MiningCore: mining/setup/miningcore.md
           - MiningCore on Windows: mining/setup/pool_win.md
-      - Governance & Economics:
-          - Governance Overview: mining/governance.md
-          - Voting: mining/gov/voting.md
-          - Forking Overview: mining/gov/forking.md
-          - Soft Forks: mining/gov/soft-fork.md
-          - Velvet Forks: mining/gov/velvet-fork.md
-          - Hard Forks: mining/gov/hard-fork.md
-          - Revenue: mining/revenue.md
       - Miner Tooling:
           - GuapSwap: eco/guapswap.md
           - Lithos: eco/lithos.md
@@ -703,4 +415,305 @@ nav:
           - Log-Space Mining: mining/log_space.md
           - Smartpools: mining/smartpools.md
           - Subpooling: mining/setup/subpool.md
-
+  - Using Ergo:
+      - Wallets & Payments:
+          - Wallet Overview: dev/wallets.md
+          - Addresses & Keys:
+              - Address Overview: dev/wallet/address.md
+              - Address Types: dev/wallet/address/address_types.md
+              - Address Validation: dev/wallet/address/address_validation.md
+              - Wallet Keys: dev/wallet/keys.md
+          - Wallet Guides:
+              - Wallet Setup: node/wallet-setup.md
+              - Satergo: dev/wallet/satergo.md
+              - Nautilus: dev/wallet/nautilus.md
+              - Minotaur: dev/wallet/minotaur.md
+              - Minotaur Multi-Sig: dev/wallet/minotaur-multisig.md
+              - SAFEW: dev/wallet/safew.md
+              - Ledger: dev/wallet/payments/ledger.md
+              - Paper Wallet: dev/wallet/paper-wallet.md
+              - Satergo Vault: dev/wallet/satergo-vault.md
+          - Make Payments & Authenticate:
+              - ErgoPay Overview: dev/wallet/payments/ergopay/ergo-pay.md
+              - ErgoPay Tutorial: dev/wallet/payments/ergopay/ep-tutorial.md
+              - ErgoAuth: dev/wallet/payments/ergoauth.md
+              - dApp Connector: dev/wallet/payments/dApp.md
+              - Proxy Contracts: dev/wallet/payments/proxy.md
+              - Assembler: dev/stack/assembler.md
+          - Standards & Integration:
+              - MultiSig: dev/wallet/multisig.md
+              - UTXO-Set Scanning Wallet API: dev/wallet/standards/eip1.md
+              - Deterministic Wallet Standard: dev/wallet/standards/eip3.md
+              - Cold Wallet Standard: dev/wallet/standards/eip19.md
+              - EIP Standards Overview: dev/wallet/eip-standards.md
+              - EIP-0005: dev/wallet/standards/eip5.md
+              - Integration Guide: dev/Integration/guide.md
+              - Transaction Lifecycle: dev/integration/transaction-lifecycle.md
+              - Dust Collection: dev/integration/dust-collection.md
+      - Ecosystem & Use Cases:
+          - Overview: uses/use-cases-overview.md
+          - Bridges & Infrastructure:
+              - Artificial Intelligence: ai.md
+              - Rosen Bridge:
+                  - eco/rosen.md
+                  - Watchers:
+                      - eco/rosen/watcher.md
+                      - Prerequisites: eco/rosen/rosen-preq.md
+                      - Ergo Watcher: eco/rosen/ergo-watcher.md
+                      - Bitcoin Watcher: eco/rosen/bitcoin-watcher.md
+                  - Guards: eco/rosen/rosen-guard.md
+                  - Tokenomics: eco/rosen/rosen-tokenomics.md
+                  - Team: eco/rosen/rosen-team.md
+                  - Uses:
+                      - eco/rosen/rosen-uses.md
+                      - rsERG-LP: tutorials/rsERGLP.md
+                      - Token Integration Guides: tutorials/token_integration.md
+              - Oracles:
+                  - uses/oracles.md
+                  - Oracle Pools V2: eco/oracles-v2.md
+                  - Mixicles: uses/mixicles.md
+              - Sidechains:
+                  - uses/sidechains.md
+                  - Sub Blocks: uses/sidechains/subblocks.md
+                  - Sigma Chains: uses/sidechains/sigma-chains.md
+                  - PoUW: uses/pouw.md
+          - Finance & Markets:
+              - Decentralized Exchanges:
+                  - uses/dex.md
+                  - ErgoDex: eco/spectrum.md
+                  - Trade House: eco/ergo-auctions.md
+                  - Palmyra: eco/palmyra.md
+                  - Crystal Pool: eco/crystal-pool.md
+                  - Machina Finance: eco/machina-finance.md
+                  - Mew Finance: eco/mew-finance.md
+                  - P2P Trading: eco/p2p-trading.md
+                  - Token Jay: eco/token-jay.md
+                  - Single Tx Swap: eco/single-tx-swap.md
+              - Monetary Systems:
+                  - SigmaUSD: uses/sigmausd.md
+                  - ChainCash: uses/chaincash.md
+                  - Gluon: eco/gluon.md
+                  - DexyGold: eco/dexy.md
+                  - Local Exchange Trading Systems:
+                      - uses/lets.md
+                      - Basic Implementation: uses/lets/basic-imp.md
+                      - Trustless LETS: uses/lets/trustless-lets.md
+              - Decentralized Finance:
+                  - Lending Overview: uses/lending.md
+                  - duckpools: eco/duckpools.md
+                  - EXLE: eco/exle.md
+                  - SigmaFi: eco/sigmafi.md
+                  - Derivatives and Synthetics:
+                      - uses/deriv.md
+                      - Hodlbox: eco/hodlbox.md
+                      - HodlCoin: eco/hodlcoin.md
+                      - AuctionCoin: eco/auction-coin.md
+                      - OptionCoin: eco/optioncoin.md
+                      - OptionPools: eco/optionPools.md
+                      - SigmaO: eco/sigmao.md
+                  - Crowdfunding:
+                      - uses/crowdfunding.md
+                      - ErgoRaffle: eco/ergoraffle.md
+                      - Sigma Subscriptions: eco/sigma-subscriptions.md
+              - Degenerate Finance:
+                  - uses/degfi.md
+                  - Grand Gambit: eco/grand-gambit.md
+                  - Obolflip: eco/obolflip.md
+                  - Lotteries: uses/lottery.md
+                  - The Field: eco/the-field.md
+          - NFTs & Gaming:
+              - NFTs Overview: uses/nft.md
+              - ErgoAuctionHouse: eco/ergo-auctions.md
+              - SkyHarbor: eco/skyharbor.md
+              - Lilium: eco/lilium.md
+              - Gaming Overview: uses/gaming.md
+              - BlitzTCG: eco/blitz.md
+              - Cyberverse: eco/cyberverse.md
+          - Applications & Utilities:
+              - Crux Finance: eco/crux.md
+              - ErgoNames: eco/ergonames.md
+              - Celaut:
+                  - eco/celaut.md
+                  - Reputation System: eco/reputation-system.md
+              - Netnotes: eco/netnotes.md
+              - SigmaRand: eco/sigmarand.md
+              - Moria Finance: eco/moria-finance.md
+              - Trading Tools:
+                  - Arbit: uses/arbit.md
+                  - Grid Trading: uses/grid_trading.md
+                  - Off the Grid: uses/off_the_grid.md
+                  - Off the Grid Tutorial: uses/off_the_grid_tut.md
+              - Applications:
+                  - TabbyPOS: eco/tabbypos.md
+                  - PandaV: eco/pandav.md
+                  - ZenGate Global:
+                      - eco/zengate.md
+                      - Solaris Portal: eco/solaris.md
+                      - Cyberiad: eco/cyberaid.md
+          - Privacy Solutions:
+              - Mixing Overview: uses/mixer.md
+              - ErgoMixer:
+                  - eco/ergomixer.md
+                  - Identifiability: eco/ergomixer/identifiability.md
+                  - Best Practices: eco/ergomixer/best-practices.md
+                  - FAQ: eco/ergomixer/mixer-faq.md
+                  - Token: eco/ergomixer/token.md
+                  - Install on Android: eco/ergomixer/mixer-android.md
+              - SigmaJoin: eco/sigmajoin.md
+              - Stealth Addresses: uses/stealth-address.md
+              - ZK Treasury: uses/zkt.md
+              - Decentralised Anon ID: eco/ergonation.md
+          - DAO & Governance Apps:
+              - uses/dao.md
+              - Paideia: eco/paideia.md
+              - The Field DAO: eco/the-field.md
+          - Mining Ecosystem:
+              - eco/miner-tooling.md
+              - Lithos: eco/lithos.md
+              - GuapSwap: eco/guapswap.md
+              - CYTI: eco/cyti.md
+          - Further Ideas & Research:
+              - Profit Sharing: uses/profit.md
+              - Email Client for Blocked Internet: uses/blocked_web.md
+              - Flash Loans: uses/flash-loans.md
+              - Prediction Markets: uses/prediction_markets.md
+              - Insurance: uses/insurance.md
+              - Micro Credit: dev/scs/microcredit.md
+              - Mutual Credit: uses/mutual_credit.md
+              - Bonding Curve: uses/bonding.md
+              - Token Concepts:
+                  - ICOs: uses/ergo-ico.md
+                  - Index Coins: uses/index_coins.md
+                  - PoW Tokens: uses/PoW_tokens.md
+                  - Perpetual Tokens: dev/tokens/perpetual.md
+                  - Buy Back Guarantees: uses/dex-buyback.md
+  - Join & Govern:
+      - Governance & Community:
+          - Ergo Foundation:
+              - ef/ergo-foundation.md
+              - Scope: ef/ef-scope.md
+              - Treasury: ef/ef-treasury.md
+              - Votes: ef/ef-votes.md
+              - Future: ef/ef-future.md
+          - DevDao: devdao.md
+          - Sigmanauts: contribute/sigmanauts.md
+          - Partnerships: partners.md
+      - Governance & Economics:
+          - Governance Overview: mining/governance.md
+          - Voting: mining/gov/voting.md
+          - Forking Overview: mining/gov/forking.md
+          - Soft Forks: mining/gov/soft-fork.md
+          - Velvet Forks: mining/gov/velvet-fork.md
+          - Hard Forks: mining/gov/hard-fork.md
+          - Revenue: mining/revenue.md
+      - Get Involved:
+          - Overview: contribute.md
+          - Sigmanauts Program: contribute/sigmanauts.md
+          - Marketing: contribute/marketing.md
+      - Developer Contributions:
+          - Overview: contribute/devs.md
+          - Technical Guidelines: contribute/technical-guidelines.md
+          - Roles: contribute/roles.md
+          - Contribute to the Docs!: contribute/docs.md
+      - Funding & Support:
+          - Bounties: contribute/bounties.md
+          - Grants: contribute/grants.md
+      - Follow Standards & Practices:
+          - Overview: contribute/standards.md
+          - Chat Bridge: contribute/standards/chat-bridge.md
+          - ErgoTipperBot: contribute/standards/tipbot.md
+          - KYA: contribute/standards/kya.md
+          - Community Guidelines: contribute/standards/guidelines.md
+          - Moderation Guide: contribute/standards/moderation.md
+          - Analytics: contribute/standards/analytics.md
+  - Protocol & Research:
+      - Core Concepts:
+          - Protocol Overview: dev/protocol/protocol-overview.md
+          - eUTxO:
+              - dev/protocol/eutxo.md
+              - UTxO vs Account: dev/protocol/eutxo/accountveutxo.md
+              - Atomic Swaps: dev/protocol/eutxo/atomic.md
+              - Ergo vs Cardano: dev/protocol/eutxo/ergo_vs_cardano.md
+              - UTXO State: dev/protocol/eutxo/utxo-state.md
+          - NIPoPoWs:
+              - dev/protocol/nipopows.md
+              - Light Clients: dev/protocol/nipopow/nipopow_nodes.md
+              - Light Miners: dev/protocol/nipopow/logspace.md
+              - Sidechains: dev/protocol/nipopow/nipopow-sidechains.md
+          - Privacy:
+              - dev/protocol/zkp.md
+              - Privacy Guide: doc/privacy-guide.md
+          - Storage Rent: dev/protocol/storage-rent.md
+          - Autolykos: dev/protocol/autolykos-protocol.md
+      - Research Library:
+          - documents.md
+          - Whitepaper: doc/whitepaper.md
+          - ErgoScript Whitepaper: doc/ergoscript-whitepaper.md
+          - On Contractual Money: doc/on-contractual-money.md
+      - Roadmap & Scaling:
+          - Roadmap Overview: roadmap.md
+          - Scaling Overview: dev/protocol/scaling.md
+          - Layer 0:
+              - dev/protocol/scaling/layer0.md
+              - Sub Blocks:
+                  - uses/sidechains/subblocks.md
+                  - Technical Details: uses/sidechains/input-blocks.md
+          - Layer 1: dev/protocol/scaling/layer1.md
+          - Layer 2: dev/protocol/scaling/layer2.md
+          - Discussions:
+              - Roadmaps: dev/protocol/scaling/scaling-roadmap.md
+              - Transactions Per Second: dev/protocol/scaling/TPS.md
+              - Atomic Composability: dev/protocol/scaling/atomic-composability.md
+      - Cryptography & Data Structures:
+          - Cryptography Overview: crypto.md
+          - Sigma Protocols:
+              - dev/scs/sigma.md
+              - Schnorr:
+                  - dev/scs/sigma/schnorr.md
+                  - Verifying Schnorr Signatures: dev/scs/sigma/verifying.md
+              - Diffie-Hellman: dev/scs/sigma/diffie.md
+              - Other Signatures:
+                  - Ring Signatures: dev/data-model/ring.md
+                  - Threshold Signatures: dev/data-model/threshold.md
+                  - 3-out-of-5 Threshold Signature: dev/scs/sigma/3-out-of-5.md
+                  - Distributed Signatures: node/sigs.md
+                  - Signature Scheme Internals: sig-scheme.md
+                  - Improved Signatures: dev/scs/sigma/improved-signatures.md
+          - Zero-Knowledge Proofs:
+              - Non-Interactive ZK: dev/data-model/nizk.md
+              - ZeroJoin: dev/crypto/zerojoin.md
+          - Data Structures:
+              - Overview: dev/data-model/data-structures.md
+              - Merkle Trees:
+                  - dev/data-model/structures/merkle/merkle-tree.md
+                  - Format: dev/data-model/structures/merkle/merkle-format.md
+                  - Validation: dev/data-model/structures/merkle/merkle-validation.md
+                  - Considerations: dev/data-model/structures/merkle/merkle-considerations.md
+                  - Extension Block Merkle: dev/data-model/structures/merkle/merkle-extension.md
+                  - Transaction Merkle Trees: dev/protocol/tx/tx-merkle.md
+                  - Merkle Batch Proofs: dev/data-model/structures/merkle/merkle-batch-proof.md
+                  - Batch Implementation: dev/data-model/structures/merkle/merkle-batch-impl.md
+                  - Batch Testing: dev/data-model/structures/merkle/merkle-batch-testing.md
+                  - Lightweight Client Proofs: dev/data-model/structures/merkle/merkle-light-proof.md
+              - AVL Trees: dev/protocol/avl.md
+              - Plasma Library: dev/lib/plasma.md
+          - Proof-of-Proof-of-Work: dev/data-model/structures/popow.md
+          - Interlink Vectors: dev/data-model/structures/interlink-vectors.md
+      - Proof-of-Work & Mining Theory:
+          - Autolykos Overview: mining/autolykos.md
+          - Algorithm Details:
+              - Emission: mining/emission.md
+              - EFYT: efyt.md
+              - Difficulty Adjustment: mining/difficulty.md
+              - Solution Verification: mining/solution-verification.md
+              - Technical Breakdown: mining/algo-technical.md
+          - Storage Rent:
+              - Overview: mining/rent.md
+              - Fees: mining/rent/rent-fees.md
+              - Tokens: mining/rent/rent-tokens.md
+              - Spending: mining/rent/rent-spending.md
+              - State Growth: mining/rent/rent-paper.md
+          - ASIC Resistance: mining/asic.md
+          - EIPs:
+              - Emission Retargeting Soft-Fork: mining/standards/eip27.md
+              - Tweaking Difficulty Adjustment Algorithm: mining/standards/eip37.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -109,3 +109,7 @@ validators==0.34.0
 watchdog==6.0.0
 wcwidth==0.2.13
 webencodings==0.5.1
+
+mkdocs-breadcrumbs-plugin>=0.2
+mkdocs-pagetree-plugin>=0.3
+mkdocs-redirects>=1.2


### PR DESCRIPTION
## Summary
- enable Material navigation sections/footer and add breadcrumbs, pagetree, and redirects plugins with link validation settings
- restructure the nav into Learn Ergo, Build on Ergo, Run Nodes & Mine, Using Ergo, Join & Govern, and Protocol & Research while adding audience and site map pages
- append required MkDocs plugin dependencies to requirements.txt

## Testing
- `pip install -r requirements.txt` *(fails: mkdocs-breadcrumbs-plugin unavailable via proxy)*
- `mkdocs serve` *(fails: breadcrumbs plugin not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68d5477e8c4083258f18cbf20294e90e