### PR TITLE
docs: update AppKit 6 release notes

### DIFF
--- a/docs/dev/stack/appkit.md
+++ b/docs/dev/stack/appkit.md
@@ -4,7 +4,7 @@ tags:
   - Scala
   - Kotlin
 owner: docs
-last_reviewed: 2026-06-15
+last_reviewed: 2026-07-17
 source_repos:
   - repo: ergoplatform/ergo-appkit
     branch: develop
@@ -23,9 +23,9 @@ source_of_truth:
 
 ## Recent updates
 
-- `Jun 7`: [AppKit v6.0.0](https://github.com/ergoplatform/ergo-appkit/releases/tag/v6.0.0) was released on top of SigmaSDK 6.0.x.
-- The release includes the [PR #253](https://github.com/ergoplatform/ergo-appkit/pull/253) EIP-50 upgrade work, Sigma 6.0 alignment, and prover-evaluated tests so contract tests can exercise newer Sigma features consistently.
-- AppKit 6 compiles Sigma 6 scripts as ErgoTree v3 when the context has `blockVersion >= 4`, while preserving the legacy v5 path for older contexts. Its Sigma 6 test coverage includes bitwise/shift operations, `serialize`, `deserializeTo`, `fromBigEndianBytes`, `startsWith`, lazy `getOrElse`, `Box.getReg`, `Header.checkPow`, unsigned-bigint operations, and context-extension conversion behavior.
+- [AppKit v6.0.0](https://github.com/ergoplatform/ergo-appkit/releases/tag/v6.0.0) was released on July 14, 2026, on top of Sigma SDK 6.0.x.
+- The release includes the [PR #253](https://github.com/ergoplatform/ergo-appkit/pull/253) Sigma 6.0 / EIP-50 upgrade and prover-evaluated tests.
+- It removes the CLI capability and `RetrofitUtil.java`, removes two vulnerable libraries and SQL `Date` references, adds `Automatic-Module-Name`, and updates sbt, Scala, and plugins. Review the [full changelog](https://github.com/ergoplatform/ergo-appkit/compare/v5.0.4...v6.0.0) before upgrading an existing integration.
 
 It is a thin wrapper around core components provided by the ErgoScript interpreter and Ergo protocol implementations which are written in Scala. It is published on [maven repository](https://mvnrepository.com/artifact/org.ergoplatform/ergo-appkit) and cross-compiled to both Java 7 and Java 8+ jars.
 


### PR DESCRIPTION
# docs: update AppKit 6 release notes

## Summary

Correct the AppKit v6.0.0 release date and document its Sigma 6.0 / EIP-50 upgrade, compatibility-related changes, and upgrade changelog.

Fixes #370

## Changes

- Update `docs/dev/stack/appkit.md` with the upstream v6.0.0 release date and release-note summary.
- Link the upstream full changelog so existing integrations can review changes before upgrading.

## Testing

Ran in a throwaway sandbox container:

```sh
python3 -m pip install -q -r requirements.txt && \
python3 tools/source_watch.py scan --strict && \
python3 tools/nav_audit.py --strict && \
python3 tools/structure_audit.py --strict && \
git diff --check && \
mkdocs build
```

All checks passed.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
