### PR TITLE
Resolve Source Watch review backlog

### DIFF
--- a/docs/contribute/source-watch-inventory.md
+++ b/docs/contribute/source-watch-inventory.md
@@ -68,13 +68,13 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | [`odiseusme`](https://github.com/odiseusme) | Developer / project | 3 | 5 | 5 |
 | [`a-shannon`](https://github.com/a-shannon) | Developer / project | 3 | 4 | 3 |
 | [`arobsn`](https://github.com/arobsn) | Developer / project | 3 | 4 | 1 |
+| [`BetterMoneyLabs`](https://github.com/BetterMoneyLabs) | Ecosystem org | 3 | 4 | 10 |
 | [`ChainCashLabs`](https://github.com/ChainCashLabs) | Ecosystem org | 1 | 4 | 5 |
 | [`DeCo-Education`](https://github.com/DeCo-Education) | Developer / project | 2 | 4 | 4 |
 | [`FlyingPig5`](https://github.com/FlyingPig5) | Developer / project | 3 | 4 | 2 |
 | [`Lithos-Protocol`](https://github.com/Lithos-Protocol) | Ecosystem org | 2 | 4 | 4 |
 | [`anon-real`](https://github.com/anon-real) | Developer / project | 3 | 3 | 3 |
 | [`aslesarenko`](https://github.com/aslesarenko) | Developer / project | 2 | 3 | 8 |
-| [`BetterMoneyLabs`](https://github.com/BetterMoneyLabs) | Ecosystem org | 3 | 3 | 10 |
 | [`decentbob`](https://github.com/decentbob) | Developer / project | 1 | 3 | 3 |
 | [`duckpools`](https://github.com/duckpools) | Ecosystem org | 4 | 3 | 4 |
 | [`Emurgo`](https://github.com/Emurgo) | External standard/vendor | 1 | 3 | 3 |
@@ -189,6 +189,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | [`arkadianet/ergo`](https://github.com/arkadianet/ergo) | Developer / project | `main` | 2 | 1 |
 | [`arobsn/hergmes`](https://github.com/arobsn/hergmes) | Developer / project | `master` | 2 | 1 |
 | [`arobsn/ledger-ergo-js`](https://github.com/arobsn/ledger-ergo-js) | Developer / project | `master` | 2 | 1 |
+| [`BetterMoneyLabs/basis-tracker`](https://github.com/BetterMoneyLabs/basis-tracker) | Ecosystem org | `master` | 2 | 4 |
 | [`BetterMoneyLabs/braid`](https://github.com/BetterMoneyLabs/braid) | Ecosystem org | `master` | 2 | 6 |
 | [`cannonQ/ergo-p2p-options-frontend`](https://github.com/cannonQ/ergo-p2p-options-frontend) | Developer / project | `master` | 2 | 3 |
 | [`cannonQ/nft-races`](https://github.com/cannonQ/nft-races) | Developer / project | `main` | 2 | 1 |
@@ -253,7 +254,6 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | [`Auction-Coin/contracts`](https://github.com/Auction-Coin/contracts) | Developer / project | `main` | 1 | 1 |
 | [`Auction-Coin/frontend`](https://github.com/Auction-Coin/frontend) | Developer / project | `main` | 1 | 1 |
 | [`Auction-Coin/off-chain`](https://github.com/Auction-Coin/off-chain) | Developer / project | `master` | 1 | 1 |
-| [`BetterMoneyLabs/basis-tracker`](https://github.com/BetterMoneyLabs/basis-tracker) | Ecosystem org | `master` | 1 | 4 |
 | [`BetterMoneyLabs/chaincash`](https://github.com/BetterMoneyLabs/chaincash) | Ecosystem org | `master` | 1 | 1 |
 | [`Blitz-TCG/Game-Client`](https://github.com/Blitz-TCG/Game-Client) | Developer / project | `main` | 1 | 1 |
 | [`Blitz-TCG/Website`](https://github.com/Blitz-TCG/Website) | Developer / project | `main` | 1 | 1 |
@@ -398,7 +398,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 
 | Page | Repositories | Paths |
 | --- | ---: | ---: |
-| [`dev/scs/contracts.md`](contracts.md) | 25 | 40 |
+| [`dev/scs/contracts.md`](contracts.md) | 26 | 41 |
 | [`roadmap.md`](roadmap.md) | 21 | 42 |
 | [`eco/emerging-projects.md`](emerging-projects.md) | 12 | 16 |
 | [`eco/degens-world.md`](degens-world.md) | 9 | 9 |
@@ -455,7 +455,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | [`Auction-Coin/contracts`](https://github.com/Auction-Coin/contracts) | `main` | `README.md` | `docs/eco/auction-coin.md` |
 | [`Auction-Coin/frontend`](https://github.com/Auction-Coin/frontend) | `main` | `README.md` | `docs/eco/auction-coin.md` |
 | [`Auction-Coin/off-chain`](https://github.com/Auction-Coin/off-chain) | `master` | `README.md` | `docs/eco/auction-coin.md` |
-| [`BetterMoneyLabs/basis-tracker`](https://github.com/BetterMoneyLabs/basis-tracker) | `master` | `README.md`<br>`contract`<br>`docs`<br>`src` | `docs/uses/chaincash.md` |
+| [`BetterMoneyLabs/basis-tracker`](https://github.com/BetterMoneyLabs/basis-tracker) | `master` | `README.md`<br>`contract`<br>`docs`<br>`src` | `docs/dev/scs/contracts.md`<br>`docs/uses/chaincash.md` |
 | [`BetterMoneyLabs/braid`](https://github.com/BetterMoneyLabs/braid) | `master` | `README.md`<br>`docs/bitcoin-mergedmining.md`<br>`docs/braid.md`<br>`docs/ergo-mergedmining.md`<br>`whitepaper/whitepaper.pdf`<br>`whitepaper/whitepaper.tex` | `docs/uses/sidechains.md`<br>`docs/uses/sidechains/braid.md` |
 | [`BetterMoneyLabs/chaincash`](https://github.com/BetterMoneyLabs/chaincash) | `master` | `docs/presentation/basis.pdf` | `docs/uses/chaincash.md` |
 | [`Blitz-TCG/Game-Client`](https://github.com/Blitz-TCG/Game-Client) | `main` | `README.md` | `docs/eco/blitz.md` |

--- a/docs/dev/interact.md
+++ b/docs/dev/interact.md
@@ -6,7 +6,7 @@ tags:
   - Explorer
   - API
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master

--- a/docs/dev/lib/ergots.md
+++ b/docs/dev/lib/ergots.md
@@ -7,7 +7,7 @@ tags:
   - NiPoPoW
   - libraries
 owner: docs
-last_reviewed: 2026-07-02
+last_reviewed: 2026-08-20
 source_repos:
   - repo: mwaddip/ergots
     branch: master
@@ -36,16 +36,16 @@ source_of_truth:
 The repository is organized as a workspace:
 
 - `@ergots/scorex`: Scorex wire codecs, block header types, digest helpers, and Autolykos v2 proof-of-work verification.
-- `@ergots/nipopow`: NiPoPoW proof parsing, serialization, verification, comparison, and P2P envelope codecs.
-- `@ergots/avltree`: Batch AVL+ authenticated-tree verification.
+- `@ergots/nipopow`: NiPoPoW proof parsing, serialization, verification, comparison, in-memory and demand-loaded proving, continuous-mode verification, and P2P envelope codecs.
+- `@ergots/avltree`: Batch AVL+ authenticated-tree verification and proving, including versioned persistent storage and rollback support.
 - `@ergots/ergoscript`: ErgoTree parsing, serialization, partial evaluation, sigma-protocol verification, AVL+ integration, and method-handler work.
 - `@ergots/transaction`: browser-clean transaction wire codec and validation package.
 
-Current package metadata lists `@ergots/scorex` `0.3.0`, `@ergots/nipopow` `0.2.1`, `@ergots/avltree` `0.2.0`, `@ergots/ergoscript` `0.5.0`, and `@ergots/transaction` `0.1.0`. Check npm and the repository before pinning a package version in an application.
+Current package metadata lists `@ergots/scorex` `0.3.0`, `@ergots/nipopow` `0.4.0`, `@ergots/avltree` `0.4.0`, `@ergots/ergoscript` `0.5.0`, and `@ergots/transaction` `0.1.0`. Check npm and the repository before pinning a package version in an application.
 
 June 2026 team updates marked the first npm publication for the Scorex, AVL tree, NiPoPoW, and ErgoScript packages, followed by Sigma v6 support work. The packages remain useful for differential testing and browser-side verification experiments, not as a standalone consensus authority.
 
-Recent work tightened JVM-alignment and input handling: context-extension ordering, typed context-extension keys, `Context.lastBlockUtxoRootHash`, header/pre-header accessors, v6 type gates, option tags, SBox/ErgoTree deserialization, box equality, collection equality costing, `atLeast` children caps, static signatures for selected methods, and `estimateCryptoCost` for JVM-faithful sigma-verification cost estimates. The README reports `7028` tests passing across packages under both `node` and `jsdom`.
+Recent work tightened JVM-alignment and input handling: context-extension ordering, typed context-extension keys, `Context.lastBlockUtxoRootHash`, header/pre-header accessors, v6 type gates, option tags, SBox/ErgoTree deserialization, box equality, collection equality costing, `atLeast` children caps, static signatures for selected methods, and `estimateCryptoCost` for JVM-faithful sigma-verification cost estimates. AVL work added `BatchAVLProver.restoreRoot`, exported node/storage helpers, a storage codec, and a versioned persistent prover. NiPoPoW `0.4.0` added prover entry points and continuous-mode proof handling. The README reports `7492` tests passing across packages under both `node` and `jsdom`.
 
 Important caveat: upstream still describes `ergots` as not yet a consensus-complete kernel. Use it for browser-side research, differential testing, and verification experiments; combine it with sigma-rust or a JVM node before relying on it for binding consensus decisions.
 

--- a/docs/dev/p2p/BlockP2P.md
+++ b/docs/dev/p2p/BlockP2P.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-05-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master

--- a/docs/dev/p2p/modifiers-exchange.md
+++ b/docs/dev/p2p/modifiers-exchange.md
@@ -2,7 +2,7 @@
 tags:
 - P2P
 owner: docs
-last_reviewed: 2026-05-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -50,6 +50,8 @@ The Modifier Exchange process involves several steps:
 
 3. **Modifier Delivery (Modifier)**: The node that initially sent the Inv message responds with a Modifier message that delivers the requested modifiers. This message contains the actual data (e.g., block sections, transactions) needed by the requesting node.
         - **Code Reference**: The `ModifiersSpec` class in the [network/message](https://github.com/ergoplatform/ergo/blob/master/ergo-core/src/main/scala/org/ergoplatform/network/message/ModifiersSpec.scala) directory is responsible for managing the delivery of modifiers.
+
+The reference node derives its global P2P frame cap from the modifier limit: `MessageConstants.MaxMessageSize` is twice `ModifiersSpec.maxMsgSizeWithReserve`, while that reserve is four times the base modifier-message limit. Implementations should follow the current constants instead of hard-coding the former 16 MiB value.
 
 This process ensures that all nodes in the network maintain an up-to-date state of the blockchain, crucial for the integrity and performance of the Ergo network.
 

--- a/docs/dev/p2p/network.md
+++ b/docs/dev/p2p/network.md
@@ -2,7 +2,7 @@
 tags:
   - P2P
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: mwaddip/ergo-proxy
     branch: master

--- a/docs/dev/protocol/audit.md
+++ b/docs/dev/protocol/audit.md
@@ -3,7 +3,7 @@ tags:
   - Security
   - Audit
 owner: docs
-last_reviewed: 2026-06-08
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ScorexFoundation/sigmastate-interpreter
     branch: develop

--- a/docs/dev/scs/contracts.md
+++ b/docs/dev/scs/contracts.md
@@ -3,8 +3,12 @@ tags:
   - ErgoScript
   - Contracts
 owner: docs
-last_reviewed: 2026-05-26
+last_reviewed: 2026-08-20
 source_repos:
+  - repo: BetterMoneyLabs/basis-tracker
+    branch: master
+    paths:
+      - contract
   - repo: ChainCashLabs/chaincash
     branch: master
     paths:
@@ -121,6 +125,7 @@ source_repos:
     paths:
       - contracts
 source_of_truth:
+  - https://github.com/BetterMoneyLabs/basis-tracker/tree/master/contract
   - https://github.com/ChainCashLabs/chaincash/tree/master/contracts
   - https://github.com/Ergo-Lend/edge/tree/main/src/main/scala/edge/contracts/Contract.scala
   - https://github.com/ErgoRaffle/raffle-backend/tree/master/app/raffle/RaffleContract.scala
@@ -234,7 +239,7 @@ The [ergo-contracts](https://github.com/ergoplatform/ergo-contracts) repository 
 
 ### In Development
 
-- ChainCash contract sources have active 2026 Basis, reserve/emergency-logic, and refund-handling changes. Verify the current contract files before treating examples as stable integration targets.
+- ChainCash/Basis contract work added reserve-refund handling and AVL `insertOrUpdate` logic in July 2026, then moved the active Basis contract and specifications into [BetterMoneyLabs/basis-tracker](https://github.com/BetterMoneyLabs/basis-tracker/tree/master/contract). Verify that repository before treating examples as stable integration targets.
 - [Dexy](https://github.com/ergoplatform/ergo-jde/blob/main/kiosk/src/test/scala/kiosk/dexy/DexySpec.scala)
 - [Bitdomains](https://github.com/bitdomains/contracts)
 - [ErgoNames](https://github.com/ergonames/ergonames/blob/master/src/main/scala/)

--- a/docs/dev/scs/sigma/verifying.md
+++ b/docs/dev/scs/sigma/verifying.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-06-08
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ScorexFoundation/sigmastate-interpreter
     branch: develop

--- a/docs/dev/stack/appkit/appkit-node.md
+++ b/docs/dev/stack/appkit/appkit-node.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-05-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: aslesarenko/ergo-appkit-examples
     branch: master

--- a/docs/dev/stack/fleet.md
+++ b/docs/dev/stack/fleet.md
@@ -2,7 +2,7 @@
 tags:
   - JavaScript
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: fleet-sdk/fleet
     branch: master

--- a/docs/dev/stack/sigma-rust.md
+++ b/docs/dev/stack/sigma-rust.md
@@ -15,7 +15,7 @@ tags:
   - Ruby
   - Python
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/bounded-vec
     branch: develop
@@ -87,6 +87,7 @@ Rust implementation of [ErgoScript (sigmastate-interpreter)](sigmastate-interpre
 
 ## Recent updates
 
+- `Aug`: SANTA's AuthDS review removed fixtures for three AVL operations that are unreachable from current ErgoScript and node paths. Its reachable verifier corpus then showed JVM and `ergots` agreement on 37 of 37 fixtures. This narrows one reported divergence; it does not establish full sigma-rust or node parity.
 - `Jul`: merged development-branch conformance fixes added checked ERG summation during stateful transaction validation ([#891](https://github.com/ergoplatform/sigma-rust/pull/891)), rejected unsupported tuple arities during evaluation ([#897](https://github.com/ergoplatform/sigma-rust/pull/897)), and rejected self context-extension keys that the JVM cannot construct ([#906](https://github.com/ergoplatform/sigma-rust/pull/906)). These fixes are not a new tagged `ergo-lib` release; downstream users should verify their pinned revision.
 - `Jun`: SANTA-backed conformance work exposed a broad sigma-rust/JVM alignment stream. Review and PR work covered JIT costing, v5/v6 evaluation behavior, AVL method semantics, context-extension handling, header-version signedness, serializer details, and other consensus-sensitive edge cases. Treat this as an active review stream unless a downstream release explicitly marks the relevant path stable.
 - `May`: early SANTA runs found synthetic sigma-rust cases accepted by sigma-rust but rejected by Scala. An independent `ergots` harness hit the same under-charging class around mainnet block `1,520,813`, reinforcing that cross-implementation test failures must be treated as consensus-sensitive until fixed upstream.

--- a/docs/dev/wallet/keys.md
+++ b/docs/dev/wallet/keys.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-06-30
+last_reviewed: 2026-08-20
 source_repos:
   - repo: satoshilabs/slips
     branch: master

--- a/docs/dev/wallet/standards/eip1.md
+++ b/docs/dev/wallet/standards/eip1.md
@@ -2,7 +2,7 @@
 tags:
   - EIP
 owner: docs
-last_reviewed: 2026-05-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master

--- a/docs/dev/wallet/standards/eip3.md
+++ b/docs/dev/wallet/standards/eip3.md
@@ -2,7 +2,7 @@
 tags:
   - EIP
 owner: docs
-last_reviewed: 2026-06-30
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/eips
     branch: master

--- a/docs/eco/bottube.md
+++ b/docs/eco/bottube.md
@@ -7,7 +7,7 @@ tags:
   - AI
   - video
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: Scottcjn/bottube
     branch: main

--- a/docs/eco/celaut.md
+++ b/docs/eco/celaut.md
@@ -8,7 +8,7 @@ tags:
   - Artificial Economic Intelligence  
   - Service Virtualization  
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: celaut-project/nodo
     branch: stable
@@ -26,6 +26,7 @@ source_repos:
 source_of_truth:
   - https://github.com/celaut-project/nodo
   - https://github.com/celaut-project/nodo/releases/tag/v2
+  - https://github.com/celaut-project/nodo/releases/tag/guest-kernel-v2
   - https://github.com/celaut-project/paradigm
   - https://github.com/celaut-project/skills
   - https://celaut-project.github.io/skills/?env=dev
@@ -46,6 +47,7 @@ Celaut is a decentralized, peer-to-peer runtime for deploying and coordinating *
 - `Apr 9`: Celaut Node was being tested with [Game of Prompts](game-of-prompts.md) before an open competition launch.
 - `May 8`: Nodo `v1` shipped a Windows 11 WSL installer. The README now marks local execution and packaging as beta on Linux and Windows, local networking and trustless networking as alpha, and macOS as unsupported.
 - `Jul 17`: Nodo `v2` refreshed the Windows 11 WSL release assets. Follow-up source fixes added `iproute2`, systemd startup, and `nodo.service` to the release root filesystem; confirm the current release assets before reinstalling an older WSL image.
+- `Aug 14`: Nodo published `guest-kernel-v2`, a pinned guest kernel plus BusyBox userspace for its Cloud Hypervisor microVM path. Install scripts select it through `GUEST_KERNEL_VERSION`; treat this component release separately from the Nodo `v2` application release.
 
 ---
 

--- a/docs/eco/celaut_v_netnotes.md
+++ b/docs/eco/celaut_v_netnotes.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: '2026-05-29'
+last_reviewed: '2026-08-20'
 source_repos:
   - repo: celaut-project/nodo
     branch: stable

--- a/docs/eco/emerging-projects.md
+++ b/docs/eco/emerging-projects.md
@@ -7,7 +7,7 @@ tags:
   - tooling
   - community
 owner: docs
-last_reviewed: 2026-06-27
+last_reviewed: 2026-08-20
 ia_status: directory
 source_repos:
   - repo: Scottcjn/bottube

--- a/docs/eco/mempool-vis.md
+++ b/docs/eco/mempool-vis.md
@@ -5,7 +5,7 @@ tags:
   - Indexing
   - ErgoHack
 owner: docs
-last_reviewed: 2026-05-30
+last_reviewed: 2026-08-20
 source_repos:
   - repo: 2ndtlmining/Ergomempool
     branch: main

--- a/docs/eco/rosen.md
+++ b/docs/eco/rosen.md
@@ -7,7 +7,7 @@ tags:
   - dApp
   - dApp-Beta
 owner: docs
-last_reviewed: 2026-07-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: rosen-bridge/watcher
     branch: master
@@ -51,10 +51,15 @@ source_repos:
       - src/lib
 source_of_truth:
   - https://rosen.tech
+  - https://github.com/rosen-bridge/watcher/releases/tag/6.3.1
+  - https://github.com/rosen-bridge/watcher/releases/tag/6.3.0
   - https://github.com/rosen-bridge/watcher/releases/tag/6.2.2
   - https://github.com/rosen-bridge/guard-service/releases/tag/10.0.1
+  - https://github.com/rosen-bridge/ui/releases/tag/guard-app-4.4.2
+  - https://github.com/rosen-bridge/ui/releases/tag/watcher-app-4.4.2
   - https://github.com/rosen-bridge/ui/releases/tag/guard-app-4.4.1
   - https://github.com/rosen-bridge/ui/releases/tag/watcher-app-4.4.1
+  - https://github.com/rosen-bridge/ui/releases/tag/rosen-service-4.4.0
   - https://github.com/rosen-bridge/ui/releases/tag/rosen-service-4.3.7
   - https://github.com/rosen-bridge/rosen-sdk
   - https://github.com/rosen-bridge/rosenet
@@ -111,9 +116,9 @@ Please see [this video](https://www.youtube.com/watch?v=Xsiy-yPJQ6w) for a visua
 - `Jul 21` to `Jul 24`: Rosen reported that guards rejected 84 invalid Cardano events from an unsuccessful attack. [Watcher 6.2.2](https://github.com/rosen-bridge/watcher/releases/tag/6.2.2) and [rosen-service 4.3.7](https://github.com/rosen-bridge/ui/releases/tag/rosen-service-4.3.7) now verify final Cardano transaction results in Koios and Ogmios data so failed transactions are ignored.
 - [Guard service 10.0.0](https://github.com/rosen-bridge/guard-service/releases/tag/10.0.0) integrated Firo, public event-status reporting, rejected-event storage, API rate limits, and scanner/API changes. [10.0.1](https://github.com/rosen-bridge/guard-service/releases/tag/10.0.1) followed with a Firo ElectrumX dependency fix. Released component support does not by itself prove that every Firo route or asset is enabled in the public bridge app.
 - `Feb 11` to `Apr 22`: Firo and Handshake integrations moved through watcher, guard-service, and rosen-service updates.
-- Watcher releases have moved through [6.2.2](https://github.com/rosen-bridge/watcher/releases/tag/6.2.2); prior updates included a Bitcoin Runes observation fix for Unisat pagination.
-- Guard and watcher apps have moved through [guard-app-4.4.1](https://github.com/rosen-bridge/ui/releases/tag/guard-app-4.4.1) and [watcher-app-4.4.1](https://github.com/rosen-bridge/ui/releases/tag/watcher-app-4.4.1). Guard app 4.4.1 fixes value display in manual transaction submission; watcher app 4.4.1 standardizes confirmation and API-key protection around lock, unlock, and withdrawal actions.
-- Rosen UI/service releases have moved through [rosen-service 4.3.7](https://github.com/rosen-bridge/ui/releases/tag/rosen-service-4.3.7).
+- [Watcher 6.3.0](https://github.com/rosen-bridge/watcher/releases/tag/6.3.0) integrated Firo, added file-logger options, and updated observation extractors; Rosen asked all watcher operators, not only Firo operators, to update. [6.3.1](https://github.com/rosen-bridge/watcher/releases/tag/6.3.1) fixed YAML/YML node-config parsing.
+- Guard and watcher apps have moved through [guard-app-4.4.2](https://github.com/rosen-bridge/ui/releases/tag/guard-app-4.4.2) and [watcher-app-4.4.2](https://github.com/rosen-bridge/ui/releases/tag/watcher-app-4.4.2). These `4.4.2` releases only update the shared UI-kit dependency; the `4.4.1` releases contain the user-facing manual-transaction and protected-action fixes.
+- [rosen-service 4.4.0](https://github.com/rosen-bridge/ui/releases/tag/rosen-service-4.4.0) integrated Firo and added file-logger options.
 - Rosen shared packages also moved through [rosen-sdk](https://github.com/rosen-bridge/rosen-sdk), [rosenet](https://github.com/rosen-bridge/rosenet), and [sign-protocols](https://github.com/rosen-bridge/sign-protocols) updates. The older [rosen-chains](https://github.com/rosen-bridge/rosen-chains) package repository is archived; chain packages moved into guard-service.
 - [network-client](https://github.com/rosen-bridge/network-client) is the Rosen client-library monorepo used by `@rosen-clients/*` packages.
 - [cleanup-service](https://github.com/rosen-bridge/cleanup-service) is Rosen infrastructure for cleanup flows such as fraud and slash transactions.

--- a/docs/eco/rosen/bitcoin-watcher.md
+++ b/docs/eco/rosen/bitcoin-watcher.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-05-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: rosen-bridge/operation
     branch: dev
@@ -196,11 +196,22 @@ To start your watcher, configure the `local.yaml` file.
 
 ### Specify the Target Network
 
-Set the target network you're watching. Current watcher configs support `ergo`, `cardano`, `bitcoin`, `ethereum`, `binance`, `doge`, and `bitcoin-runes`:
+Set the target network you're watching. Current watcher releases also support `firo`; this page configures `bitcoin`:
 
 ```yaml
 network: bitcoin
 ```
+
+### Optional Monitoring Agents
+
+The upstream Compose setup can enable log shipping and machine/container metrics with `COMPOSE_PROFILES=logger,monitoring`. Copy `env.logger.template` and `env.monitoring.template`, configure same-host or remote observability as documented upstream, then apply:
+
+```shell
+chmod -R ao+rX ./alloy ./prometheus-agent
+chmod o+x ./prometheus-agent/entrypoint.sh
+```
+
+If Alloy ships watcher logs, configure a JSON file logger with a `current.log` symlink.
 
 ## Observation Raw Data
 

--- a/docs/eco/rosen/ergo-watcher.md
+++ b/docs/eco/rosen/ergo-watcher.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-05-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: rosen-bridge/operation
     branch: dev
@@ -120,6 +120,17 @@ docker compose up -d
 ```
 
 Access the watcher UI by visiting `http://localhost:3030` to monitor network information and health status.
+
+### Optional Monitoring Agents
+
+Upstream Docker configuration can start Alloy/log shipping and host/container metrics through Compose profiles. Deploy the observability stack first when it shares this host, set `COMPOSE_PROFILES=logger,monitoring` in `.env`, and create `.env.logger` and `.env.monitoring` from their templates. Before startup, apply the current permission commands:
+
+```shell
+chmod -R ao+rX ./alloy ./prometheus-agent
+chmod o+x ./prometheus-agent/entrypoint.sh
+```
+
+Use a JSON file logger with a `current.log` symlink when Alloy ships watcher logs. See the upstream deployment guide for same-host and remote-observability settings.
 
 ## Note
 

--- a/docs/eco/rust-chain.md
+++ b/docs/eco/rust-chain.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-07-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: Scottcjn/Rustchain
     branch: main

--- a/docs/mining/gov/hard-fork.md
+++ b/docs/mining/gov/hard-fork.md
@@ -3,7 +3,7 @@ tags:
   - Forking
   - Fork
 owner: docs
-last_reviewed: 2026-05-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master

--- a/docs/node/deploy-runbook.md
+++ b/docs/node/deploy-runbook.md
@@ -6,7 +6,7 @@ tags:
   - Indexing
   - Watchers
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -111,6 +111,8 @@ Minimum configuration pieces:
 - `observation.confirmation`: tune per watched chain. Source docs recommend `9` for Ergo, `1` for Bitcoin, `20` for Ethereum, `25` for Cardano, and `300` for Binance.
 
 Keep mnemonic and API hash in env vars where possible, not directly in shared config snippets.
+
+Optional watcher observability uses Compose `logger` and `monitoring` profiles. Deploy the observability stack first for same-host mode, copy the logger/monitoring env templates, and use the upstream permission commands `chmod -R ao+rX ./alloy ./prometheus-agent` and `chmod o+x ./prometheus-agent/entrypoint.sh` before startup.
 
 ## Rosen Guard Checklist
 

--- a/docs/node/indexed-node.md
+++ b/docs/node/indexed-node.md
@@ -6,7 +6,7 @@ tags:
   - Blockchain
   - Explorer
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master

--- a/docs/node/operations/hardening.md
+++ b/docs/node/operations/hardening.md
@@ -5,7 +5,7 @@ tags:
   - Security
   - Node
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -46,4 +46,3 @@ Use this checklist for public or semi-public node hosts.
 - Add reverse-proxy rate limits before exposing transaction, mempool, wallet, or indexed query routes.
 - For browser apps, set CORS narrowly when you know the origin. `corsAllowedOrigin = "*"` is convenient but broad.
 - Treat the plain `api_key` header as a secret; TLS or tunnels matter because config stores only the hash.
-

--- a/docs/node/operations/reverse-proxy.md
+++ b/docs/node/operations/reverse-proxy.md
@@ -5,7 +5,7 @@ tags:
   - Reverse Proxy
   - API
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -49,4 +49,3 @@ For local admin, SSH tunnel is often simpler:
 ```shell
 ssh -L 9053:127.0.0.1:9052 user@node-host
 ```
-

--- a/docs/node/operations/testnet-devnet.md
+++ b/docs/node/operations/testnet-devnet.md
@@ -5,7 +5,7 @@ tags:
   - Devnet
   - Operations
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -35,4 +35,4 @@ Use testnet for public compatibility testing. Use devnet/private fork when you n
 - Never reuse production wallet seeds.
 - Pin config files in version control for repeatable devnet tests.
 - For private chains, document genesis/config changes next to deployment scripts.
-
+- Current `testnet.conf` sets `version2ActivationHeight = 2147483647` and `version2ActivationDifficultyHex = "20"`, effectively disabling the historical protocol-v2/client-4.0 hard fork on public testnet. Do not assume public testnet reproduces that mainnet activation boundary; use a controlled devnet when testing activation behavior.

--- a/docs/node/operations/upgrades.md
+++ b/docs/node/operations/upgrades.md
@@ -5,7 +5,7 @@ tags:
   - Upgrades
   - Rollback
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master

--- a/docs/node/rust-node.md
+++ b/docs/node/rust-node.md
@@ -5,7 +5,7 @@ tags:
   - Infrastructure
   - Experimental
 owner: docs
-last_reviewed: 2026-07-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: mwaddip/ergo-node-rust
     branch: master
@@ -43,6 +43,13 @@ source_repos:
       - README.md
 source_of_truth:
   - https://github.com/mwaddip/ergo-node-rust
+  - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.8.1
+  - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.8.0
+  - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.11
+  - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.10
+  - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.9
+  - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.8
+  - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.7
   - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.6
   - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.5
   - https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.4
@@ -87,6 +94,10 @@ Related Rust-node references include [Luivatra/ergo-rust-node](https://github.co
 
 Recent release highlights:
 
+- [v0.8.1](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.8.1) aligned `CONTEXT.headers` with the reference node's nine preceding headers and allowed missing-parent requests to resume after the unknown-parent request budget had been exhausted.
+- [v0.8.0](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.8.0) removed deferred script evaluation, introduced derived memory-budget and split-cache settings, moved Debian configuration into `/etc/ergo-node/conf.d/`, and fixed external-miner candidates, at-tip candidate serving, and mempool admission. UTXO mode now refuses to start below a 3 GiB memory ceiling unless the operator explicitly overrides the floor.
+- [v0.7.11](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.11) fixed a reorg header-index overwrite and fast-sync cold-start gap, and added offline state compaction. Operators whose `v0.7.5`–`v0.7.10` index is already clobbered still need a resync.
+- [v0.7.10](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.10) stopped unbounded `state.redb` growth; it does not reclaim existing unreachable rows. [v0.7.9](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.9), [v0.7.8](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.8), and [v0.7.7](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.7) fixed P2P frame sizing and several restart/at-tip proof-digest failures.
 - [v0.7.6](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.6) fixed an AVL-tree persistence bug that could omit rebalanced internal nodes and later cause resolver-miss panics at the chain tip. The release notes require operators upgrading from an earlier version to delete the node's local `state.redb` and resync because existing state may already be incomplete.
 - [v0.7.5](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.5) added the missing proof-digest consensus check after block application, fixed genesis/proof-generation ordering needed for canonical proofs, and decoupled validation sweeps from download progress. The release notes say SANTA isolated a live testnet divergence; this reinforces the node's experimental status.
 - [v0.7.4](https://github.com/mwaddip/ergo-node-rust/releases/tag/v0.7.4) fixed a mining-serve state-root mismatch at tip by building a fresh prover from storage rather than sharing mutable prover tree state.
@@ -110,6 +121,8 @@ Current development areas include mining endpoint support, NiPoPoW bootstrapping
 
 - Mainnet validation work exposed sigma-rust edge cases around context-extension ordering, v6 opcode parsing, JIT costing, lazy constant resolution, and pre-JIT compatibility paths.
 - SANTA and independent `ergots` validation both exposed a sigma-rust under-charging divergence in May 2026. That kind of cross-runner failure is useful evidence for conformance work, but the Scala node remains the consensus authority.
+- SANTA's August AuthDS review retired three AVL operations that are unreachable from current ErgoScript/node paths. On the remaining reachable corpus, its JVM and `ergots` runners agreed on all 37 verifier fixtures; this is scoped conformance evidence, not a general production-readiness claim.
+- The independent `arkadianet/ergo` node now separates Scala-compatible API documentation at `/swagger` from its native Rust API family at `/swagger/native`.
 - The peer-penalty system was designed to integrate with `fail2ban`, but repeated or malformed request behavior still needed tuning during April testing.
 - Memory work focused on reducing database cache pressure after the node reaches tip. The `v0.4.0` release reopened the runtime AVL state database with a smaller redb cache once chain sync completed.
 - NiPoPoW work included bootstrapping and proof-serving gaps. One noted difference was that the sigma-rust `NipopowProof` structure lacked a `continuous` field present in the JVM node.

--- a/docs/node/scanner-ops.md
+++ b/docs/node/scanner-ops.md
@@ -5,7 +5,7 @@ tags:
   - Indexing
   - Node API
 owner: docs
-last_reviewed: 2026-05-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -54,4 +54,3 @@ Use [Indexed Node API](indexed-node.md), [Explorer Stack](explorer-stack.md), or
 - Back up node wallet/scanner state if service depends on it.
 - Monitor scan results after node upgrades or rescans.
 - Do not expose scan-management routes publicly.
-

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 tags:
   - Roadmap
 owner: docs
-last_reviewed: 2026-07-27
+last_reviewed: 2026-08-20
 source_repos:
   - repo: ergoplatform/eips
     branch: master
@@ -275,7 +275,7 @@ These timeline items matter for continuity. Treat them as current work only when
 
 - [x] [AppKit v6.0.0](https://github.com/ergoplatform/ergo-appkit/releases/tag/v6.0.0) released on top of SigmaSDK 6.0.x, including EIP-50 / Sigma 6.0 alignment work and prover-evaluated tests.
 - [x] [Sigma SDK v6.0.5](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.5) released after the 6.0.0 through 6.0.4 releases, adding regression coverage and serialization/deserialization hardening.
-- [x] Ergo node releases moved through `v6.0.2`, `v6.0.2.1`, `v6.0.2.2`, `v6.0.3RC1`, [v6.0.3](https://github.com/ergoplatform/ergo/releases/tag/v6.0.3), [v6.1.3](https://github.com/ergoplatform/ergo/releases/tag/v6.1.3), and [v6.0.4RC2](https://github.com/ergoplatform/ergo/releases/tag/v6.0.4RC2); [Ergo Matrix 6.5.0 RC3](https://github.com/ergoplatform/ergo/releases/tag/v6.5.0-RC3) is the current special DevNet build for protocol-breaking-change testing and p2p-layer fixes.
+- [x] Ergo node releases moved through `v6.0.2`, `v6.0.3`, [v6.0.4](https://github.com/ergoplatform/ergo/releases/tag/v6.0.4), and the RocksDB-equivalent [v6.1.4](https://github.com/ergoplatform/ergo/releases/tag/v6.1.4); [Ergo Matrix 6.5.0 RC3](https://github.com/ergoplatform/ergo/releases/tag/v6.5.0-RC3) remains the special DevNet build for protocol-breaking-change testing and p2p-layer fixes.
 - [x] Node protocol work improved mempool consistency, extension-section validation, missing-parent header handling, SyncInfoV2 continuation-header handling, and Matrix input-block transaction-body digest checks. See [Ergo Node Protocol](protocol.md), [Synchronisation](synchronisation.md), and [Sub-blocks](subblocks.md).
 - [x] [Lithos](lithos.md) moved through `v3.0.0-test`, `v3.1.0-test`, `v4.0.0-test`, `v4.1.0-test`, and [`v4.2.0-test`](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v4.2.0-test), with work on mempool tracking, Stratum behavior, transaction scheduling, and rollup evaluation.
 - [x] [ChainCash](chaincash.md) and Basis advanced through reserve-contract rework, tracker persistence, on-chain state-update testing, note redemption, server/API work, and presentation material for 2026 research events.
@@ -283,8 +283,8 @@ These timeline items matter for continuity. Treat them as current work only when
 - [x] [Machina Finance](machina-finance.md) published an alpha orders SDK with grid and limit-order transaction builders.
 - [x] [Etcha](etcha.md) entered alpha for peer-to-peer options with physical-delivery and cash-settled flows.
 - [x] [Degen Wallet](degens-world.md), Degens.World agent tooling, Ergo MCP, Xergon, and related experimental apps expanded the wallet/agent surface.
-- [x] [Rust node](rust-node.md) releases reached v0.7.6, which fixed an AVL persistence bug and requires earlier-version state to be discarded and resynced. SANTA added shared conformance vectors/runners for `sigma-rust`, `arkadianet/ergo`, and `mwaddip/ergo-node-rust`.
-- [x] [ergots](ergots.md) published browser-compatible TypeScript packages for Scorex codecs, NiPoPoW, AVL+, ErgoScript, and transaction tooling, with current package metadata tracked in docs.
+- [x] [Rust node](rust-node.md) releases reached v0.8.1, adding memory-budget/configuration work and fixing mining, mempool, reorg, storage-growth, proof-digest, header-context, and missing-parent recovery issues. It remains experimental. SANTA added shared conformance vectors/runners for `sigma-rust`, `arkadianet/ergo`, and `mwaddip/ergo-node-rust`.
+- [x] [ergots](ergots.md) published browser-compatible TypeScript packages for Scorex codecs, NiPoPoW, AVL+, ErgoScript, and transaction tooling; NiPoPoW and AVL+ packages reached `0.4.0` with prover and storage work.
 - [x] [Matrix Pulse](matrix-pulse.md) was published as lightweight Matrix input-block observability tooling for local Matrix nodes.
 - [x] [eBiome](ebiome.md) launched as a live ecosystem analytics, explorer, and forensics dashboard; its forensics views are heuristic and should not be treated as deterministic attribution.
 - [x] [Ergo Marketplace](ergo-marketplace.md) was published as an early design/prototype for permissionless trade infrastructure.
@@ -341,8 +341,8 @@ The emphasis in 2026 is validation and application work on top of the 6.x stack,
 | AppKit | 6.0.0 released on SigmaSDK 6.0.x. | Downstream library updates and examples that adopt AppKit 6. |
 | [FleetSDK](fleet.md) / ergoc | Fleet 2025 work added `AvlTree` serialization, browser bundle changes, and ErgoTree construction from ergoc JSON output. | Release notes, package entrypoints, and examples that depend on newer serialization paths. |
 | [sigma-rust](sigma-rust.md) | Compiler/interpreter parity work and bindings continue. | Consensus-sensitive parity claims, JIT costing, and binding releases. |
-| [ergots](ergots.md) | TypeScript verification and ErgoScript tooling is active, with published packages for Scorex, NiPoPoW, AVL+, ErgoScript, and transactions. | Package stability, JVM-alignment notes, and evaluator coverage. |
-| [Rust Node](rust-node.md) / SANTA | Rust node reached 0.7.x releases; SANTA supplies conformance vectors/runners for sigma-rust, arkadianet/ergo, and mwaddip/ergo-node-rust. | Cross-implementation divergences, new vector tiers, and production-readiness statements. |
+| [ergots](ergots.md) | TypeScript verification and ErgoScript tooling is active, with `0.4.0` NiPoPoW and AVL+ packages adding prover and storage surfaces. | Package stability, JVM-alignment notes, and evaluator coverage. |
+| [Rust Node](rust-node.md) / SANTA | Rust node reached `0.8.1`; SANTA supplies conformance vectors/runners for sigma-rust, arkadianet/ergo, and mwaddip/ergo-node-rust. | Cross-implementation divergences, new vector tiers, and production-readiness statements. |
 
 ### Scaling and Mining
 

--- a/docs/uses/chaincash.md
+++ b/docs/uses/chaincash.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-20
 source_repos:
   - repo: BetterMoneyLabs/chaincash
     branch: master
@@ -71,6 +71,7 @@ This article explains ChainCash's functionality, explores practical applications
 - Basis presentation slides, including the June 2026 RAMICS deck, are available in the ChainCash repository: [basis.pdf](https://github.com/BetterMoneyLabs/chaincash/blob/master/docs/presentation/basis.pdf).
 - `Jul 1`: the team reported testing tracker on-chain state updates and redemption against the Basis tracker, while preparing developer-onboarding material.
 - `Jul 19` to `Jul 21`: the public [Basis tracker](https://github.com/BetterMoneyLabs/basis-tracker) added multiple-redemption support, current-height fetching, a terminal helper, and clearer tracker-box setup and protocol documentation. The tracker commits cumulative debt mappings through an AVL-tree digest and remains prototype software.
+- `Aug 3` to `Aug 18`: the Basis tracker added a terminal wallet and MCP server, account and acceptance-policy workflows, on-chain reserve submission, stronger redemption checks, and consistent OpenAPI tests. Active Basis contract and specification files moved into the tracker repository. The server now supports optional TLS plus `none`, shared API-key, and per-request Schnorr-signature authentication modes with read/write/admin roles; production operators should not send credentials over plaintext.
 - Caveat: some transfer paths still depend on raw Schnorr signatures, so normal wallet support remains constrained.
 
 ## Motivation and Evolution of Money


### PR DESCRIPTION
## Summary

- integrate verified Ergo node, Rust node, ErgoTS, Rosen watcher, Celaut, Basis/ChainCash, testnet, and P2P updates
- mark reviewed Source Watch false positives as current without adding changelog noise
- regenerate the Source Watch inventory

## Verification

- `.venv/bin/python tools/source_watch.py scan --strict`
- `.venv/bin/python tools/source_watch_inventory.py --check`
- `.venv/bin/python tools/nav_audit.py --strict`
- `.venv/bin/python tools/structure_audit.py --strict`
- `git diff --check`
- `.venv/bin/python -m mkdocs build --site-dir /tmp/ergodocs-site-check`

## Issue review

Content updated: #503, #502, #500, #498, #494, #492, #491, #490, #486, #482, #478, #475, #473.

Source checked; existing docs remain accurate or the trigger was not documentation-relevant: #512, #511, #510, #508, #501, #499, #497, #496, #495, #493, #489, #488, #487, #485, #484, #483, #481, #480, #479, #477, #476, #474, #472.

Weekly tracker reviewed: #509.
