### PR TITLE
Integrate weekly source updates

### DIFF
--- a/docs/ai.md
+++ b/docs/ai.md
@@ -1,17 +1,12 @@
 ---
 owner: docs
-last_reviewed: 2026-07-02
+last_reviewed: 2026-08-21
 tags:
   - learn
   - research
   - artificial-intelligence
   - eUTXO
 source_repos:
-  - repo: a-shannon/Aletheia-Protocol
-    branch: main
-    paths:
-      - README.md
-      - docs
   - repo: marctheshark3/FintelligenceAI
     branch: main
     paths:
@@ -22,10 +17,16 @@ source_repos:
       - README.md
       - ergo-blockchain-system-prompt.md
       - cursor/Ergo-Blockchain-API-Guide-for-Cursormd
+  - repo: accord-protocol/accord-protocol
+    branch: main
+    paths:
+      - README.md
+      - docs/status.md
+      - specs
 source_of_truth:
-  - https://github.com/a-shannon/Aletheia-Protocol
   - https://github.com/marctheshark3/FintelligenceAI
   - https://github.com/marctheshark3/AI-Project-Starter-Kit
+  - https://github.com/accord-protocol/accord-protocol
   - https://www.ergoblockchain.org/blog/agent-economy-manifesto
   - https://www.ergoblockchain.org/blog/agent-economy-live-proof-site-update
 ---
@@ -48,7 +49,9 @@ Finally, the **complexity of integration and interoperability** cannot be unders
 
 Amidst these challenges, a particularly ambitious application is emerging: **Artificial Economic Intelligence (AEI)**. Pioneered conceptually within the Ergo ecosystem, AEI enables autonomous software agents to manage funds, perform tasks independently, generate revenue, cover operational expenses, and expand their network—all through smart contracts on a public blockchain ([10](https://forum.cardano.org/t/ergo-proof-of-work-cardano/131478)). These are not merely tools analyzing data but digital entities designed for independent economic activity.
 
-Related public experiments include [Aletheia Protocol](https://github.com/a-shannon/Aletheia-Protocol), an open-source framework and whitepaper for AI persistence on Ergo, and [FintelligenceAI](https://github.com/marctheshark3/FintelligenceAI), a modular RAG and agent framework that starts with Ergo smart-contract script generation and ErgoScript validation tooling.
+Related public experiments include [FintelligenceAI](https://github.com/marctheshark3/FintelligenceAI), a modular RAG and agent framework that starts with Ergo smart-contract script generation and ErgoScript validation tooling.
+
+[Accord Protocol](https://github.com/accord-protocol/accord-protocol) is a draft open standard for agent work agreements, verification receipts, and settlement receipts. Ergo is its first reference programmable-settlement rail, alongside rail adapters for Rosen, Base/EVM, and x402-compatible flows. The project labels its v0 implementation alpha and testnet-first; Ergo scripts and manifests are not certified for mainnet use.
 
 Developer-facing agent and media projects include [Ergo Agent SDK](ergo-agent-sdk.md), [Degens.World](degens-world.md), and [BoTTube](bottube.md).
 

--- a/docs/contribute/source-watch-inventory.md
+++ b/docs/contribute/source-watch-inventory.md
@@ -18,10 +18,10 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 ## Summary
 
 - Source-watched pages: `239`
-- Watched repositories: `234`
-- Watched GitHub owners: `101`
-- Watched repo/branch pairs: `240`
-- Watched paths: `505`
+- Watched repositories: `235`
+- Watched GitHub owners: `102`
+- Watched repo/branch pairs: `241`
+- Watched paths: `509`
 - Release-watched page/repository refs: `13`
 
 ## Coverage Groups
@@ -30,7 +30,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | --- | ---: | ---: | ---: | ---: |
 | Core / infrastructure | 5 | 30 | 132 | 189 |
 | Ecosystem org | 10 | 38 | 24 | 36 |
-| Developer / project | 82 | 162 | 119 | 94 |
+| Developer / project | 83 | 163 | 119 | 98 |
 | External standard/vendor | 4 | 4 | 11 | 13 |
 
 ## Coverage By Area
@@ -66,7 +66,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | [`input-output-hk`](https://github.com/input-output-hk) | External standard/vendor | 1 | 5 | 7 |
 | [`MrStahlfelge`](https://github.com/MrStahlfelge) | Developer / project | 3 | 5 | 7 |
 | [`odiseusme`](https://github.com/odiseusme) | Developer / project | 3 | 5 | 5 |
-| [`a-shannon`](https://github.com/a-shannon) | Developer / project | 3 | 4 | 3 |
+| [`a-shannon`](https://github.com/a-shannon) | Developer / project | 3 | 4 | 4 |
 | [`arobsn`](https://github.com/arobsn) | Developer / project | 3 | 4 | 1 |
 | [`BetterMoneyLabs`](https://github.com/BetterMoneyLabs) | Ecosystem org | 3 | 4 | 10 |
 | [`ChainCashLabs`](https://github.com/ChainCashLabs) | Ecosystem org | 1 | 4 | 5 |
@@ -106,6 +106,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | [`satoshilabs`](https://github.com/satoshilabs) | External standard/vendor | 1 | 2 | 1 |
 | [`scalahub`](https://github.com/scalahub) | Core / infrastructure | 1 | 2 | 5 |
 | [`2ndtlmining`](https://github.com/2ndtlmining) | Developer / project | 1 | 1 | 1 |
+| [`accord-protocol`](https://github.com/accord-protocol) | Developer / project | 1 | 1 | 3 |
 | [`AcoSmrkas`](https://github.com/AcoSmrkas) | Developer / project | 5 | 1 | 1 |
 | [`andrehafner`](https://github.com/andrehafner) | Developer / project | 1 | 1 | 1 |
 | [`Auction-Coin`](https://github.com/Auction-Coin) | Developer / project | 3 | 1 | 1 |
@@ -235,8 +236,9 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | [`spectrum-finance/ergo-dex`](https://github.com/spectrum-finance/ergo-dex) | Ecosystem org | `master` | 2 | 1 |
 | [`StabilityNexus/Gluon-Ergo-UI`](https://github.com/StabilityNexus/Gluon-Ergo-UI) | Developer / project | `main` | 2 | 1 |
 | [`2ndtlmining/Ergomempool`](https://github.com/2ndtlmining/Ergomempool) | Developer / project | `main` | 1 | 1 |
-| [`a-shannon/Aletheia-Protocol`](https://github.com/a-shannon/Aletheia-Protocol) | Developer / project | `main` | 1 | 2 |
 | [`a-shannon/ergo-research`](https://github.com/a-shannon/ergo-research) | Developer / project | `main` | 1 | 1 |
+| [`a-shannon/ergo-sidechain-bridge`](https://github.com/a-shannon/ergo-sidechain-bridge) | Developer / project | `main` | 1 | 3 |
+| [`accord-protocol/accord-protocol`](https://github.com/accord-protocol/accord-protocol) | Developer / project | `main` | 1 | 3 |
 | [`AcoSmrkas/mew-dex`](https://github.com/AcoSmrkas/mew-dex) | Developer / project | `master` | 1 | 1 |
 | [`AcoSmrkas/mew-lock`](https://github.com/AcoSmrkas/mew-lock) | Developer / project | `main` | 1 | 1 |
 | [`AcoSmrkas/mew-prediction`](https://github.com/AcoSmrkas/mew-prediction) | Developer / project | `main` | 1 | 1 |
@@ -416,7 +418,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | [`eco/game-of-prompts.md`](game-of-prompts.md) | 4 | 5 |
 | [`node/deploy-runbook.md`](deploy-runbook.md) | 4 | 5 |
 | [`uses/chaincash.md`](chaincash.md) | 4 | 11 |
-| [`ai.md`](ai.md) | 3 | 6 |
+| [`ai.md`](ai.md) | 3 | 7 |
 | [`dev/interact.md`](interact.md) | 3 | 4 |
 | [`dev/oc/dex_bots.md`](dex_bots.md) | 3 | 7 |
 | [`dev/p2p/network.md`](network.md) | 3 | 8 |
@@ -430,9 +432,10 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | --- | --- | --- | --- |
 | [`2ndtlmining/Ergomempool`](https://github.com/2ndtlmining/Ergomempool) | `main` | `README.md` | `docs/eco/mempool-vis.md` |
 | [`4EYESConsulting/sigmalok-indexer`](https://github.com/4EYESConsulting/sigmalok-indexer) | `main` | `README.md` | `docs/dev/tutorials/blockchain-indexing.md`<br>`docs/dev/tutorials/blockchain-indexing/custom-indexer.md` |
-| [`a-shannon/Aletheia-Protocol`](https://github.com/a-shannon/Aletheia-Protocol) | `main` | `README.md`<br>`docs` | `docs/ai.md` |
 | [`a-shannon/ergo-agent-sdk`](https://github.com/a-shannon/ergo-agent-sdk) | `main` | `README.md` | `docs/dev/stack/ergo-agent-sdk.md`<br>`docs/eco/emerging-projects.md` |
 | [`a-shannon/ergo-research`](https://github.com/a-shannon/ergo-research) | `main` | `papers/curve-trees` | `docs/dev/protocol/zkp.md` |
+| [`a-shannon/ergo-sidechain-bridge`](https://github.com/a-shannon/ergo-sidechain-bridge) | `main` | `README.md`<br>`docs/public-audit-alpha-manifest.json`<br>`docs/public-audit-alpha.md` | `docs/uses/sidechains.md` |
+| [`accord-protocol/accord-protocol`](https://github.com/accord-protocol/accord-protocol) | `main` | `README.md`<br>`docs/status.md`<br>`specs` | `docs/ai.md` |
 | [`AcoSmrkas/mew-dex`](https://github.com/AcoSmrkas/mew-dex) | `master` | `README.md` | `docs/eco/mew-finance.md` |
 | [`AcoSmrkas/mew-lock`](https://github.com/AcoSmrkas/mew-lock) | `main` | `README.md` | `docs/eco/mew-finance.md` |
 | [`AcoSmrkas/mew-prediction`](https://github.com/AcoSmrkas/mew-prediction) | `main` | `README.md` | `docs/eco/mew-finance.md` |

--- a/docs/eco/project-directory.md
+++ b/docs/eco/project-directory.md
@@ -83,6 +83,7 @@ For external discovery, also check [Sigmaverse](sigmaverse.md).
 | [Netnotes](netnotes.md) | - | Active | 2026-05-19 |
 | [Ergo Relay](ergo-relay.md) | - | Active | 2026-04-13 |
 | [Matrix Pulse](matrix-pulse.md) | [GitHub](https://github.com/odiseusme/matrix-pulse) | Active Matrix tooling | 2026-07-01 |
+| [Lumen](https://github.com/from-ufa/lumen) | [ergolumen.net](https://ergolumen.net/) | Live node/oracle dashboard | 2026-08-15 |
 | [Reputation System](reputation-system.md) | [Sigma Reputation Panel](https://reputation-systems.github.io/sigma-reputation-panel/) | Active | 2026-04-07 |
 | [Ergo Proxy](ergo-proxy.md) | - | Active | 2026-03-31 |
 | [Ergo Knowledge Base](ergo-knowledge-base.md) | [transcripts](https://ergo-transcripts.vercel.app/), [knowledge base](https://ergo-knowledge-base.vercel.app/) | Active | 2026-03-10 |

--- a/docs/mining/mining-resources.md
+++ b/docs/mining/mining-resources.md
@@ -7,7 +7,7 @@ tags:
   - EIP
   - Test Vectors
 owner: docs
-last_reviewed: 2026-07-10
+last_reviewed: 2026-08-21
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -34,6 +34,8 @@ This page provides a collection of resources related to Ergo mining. It includes
 The [Ergo GitHub repository](https://github.com/ergoplatform/ergo/tree/master/src/main/scala/org/ergoplatform/mining) contains the Scala files related to Ergo's mining algorithm. This is a great resource if you're interested in understanding the technical details of Ergo mining.
 
 Recent node versions cache block candidates and regenerate them on a timed interval. The default `blockCandidateGenerationInterval` in the reference configuration is `60s`, and mining code handles expired cached candidates before producing work for miners.
+
+Reference client v6.0.4 also recovers when a locally mined block fails syntactic or semantic validation. The candidate generator clears the rejected solved block and cached candidates, while the node removes an identifiable failing transaction from the mempool; a subsequent mining request then generates fresh work instead of repeatedly returning `Block already solved`.
 
 Mainnet 6.0 voting settings were added to `mainnet.conf` with voting starting height `1561601`. The reference client advertises the 6.0.x app version while mainnet chain settings use protocol version 4 for the 6.0 interpreter feature set.
 

--- a/docs/node/install.md
+++ b/docs/node/install.md
@@ -6,7 +6,7 @@ tags:
   - Setup
   - Guide
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-21
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -16,9 +16,8 @@ source_repos:
       - src/main/scala/org/ergoplatform/nodeView/
 source_of_truth:
   - https://github.com/ergoplatform/ergo
-  - https://github.com/ergoplatform/ergo/releases/tag/v6.0.3
-  - https://github.com/ergoplatform/ergo/releases/tag/v6.0.4RC2
-  - https://github.com/ergoplatform/ergo/releases/tag/v6.1.3
+  - https://github.com/ergoplatform/ergo/releases/tag/v6.0.4
+  - https://github.com/ergoplatform/ergo/releases/tag/v6.1.4
   - https://github.com/ergoplatform/ergo/releases/tag/v6.5.0-RC3
 ---
 
@@ -50,7 +49,9 @@ The minimum hardware requirements are approximately ~20GB of storage for the blo
 
 Current reference-node configuration advertises the 6.0.x app version. Mainnet protocol settings use protocol version 4 for the 6.0 interpreter feature set.
 
-The latest checked stable reference-client releases are [v6.0.3](https://github.com/ergoplatform/ergo/releases/tag/v6.0.3) and [v6.1.3](https://github.com/ergoplatform/ergo/releases/tag/v6.1.3), published on 2026-06-26. Both include the 6.0.3 maintenance line: public testnet parameter updates, custom public-key mining route support on testnet, extension-section validation coverage, mempool and synchronisation fixes, P2P logic improvements, wallet API documentation updates, custom-key mining candidate cache fixes, and transaction-builder input-ID validation. [v6.0.4RC2](https://github.com/ergoplatform/ergo/releases/tag/v6.0.4RC2) is a newer prerelease. RC1 added stricter REST input validation, corrected testnet V2 activation settings, and duplicate-ID mempool protection; RC2 adds block-candidate generation improvements and an OpenAPI correction. For Matrix DevNet testing, [v6.5.0-RC3](https://github.com/ergoplatform/ergo/releases/tag/v6.5.0-RC3) is the current special prerelease build.
+The latest checked stable reference-client release is [v6.0.4](https://github.com/ergoplatform/ergo/releases/tag/v6.0.4), published on 2026-08-18. It adds stricter REST input validation, corrected public-testnet V2 activation settings, duplicate-ID mempool protection, block-candidate and extra-index consistency fixes, and mining recovery when a locally produced block fails validation. [v6.1.4](https://github.com/ergoplatform/ergo/releases/tag/v6.1.4) contains the same changes with RocksDB and remains marked as a prerelease. For Matrix DevNet testing, [v6.5.0-RC3](https://github.com/ergoplatform/ergo/releases/tag/v6.5.0-RC3) remains the special prerelease build.
+
+If node-view validation rejects a locally mined block, v6.0.4 clears the solved-block and candidate caches so the next mining request can build fresh work. When the validation error identifies a failing transaction, the node also removes that transaction from the mempool. Operators should still inspect the warning and underlying transaction failure; the recovery prevents the miner from remaining stuck on the rejected candidate.
 ////
 //// details | Modes of operation
     {type: notes, open: true}
@@ -104,6 +105,7 @@ For more convenience, Docker provides a streamlined way to install and run the E
 
 - [Explorer & Node Bundles](explorer-stack.md): Access pre-packaged bundles that include an Ergo Node and explorer-related services for easy setup.
 - [Ergosphere](https://ergosphere.cloud/): Ergosphere is an Umbrel-like solution that simplifies the setup of self-hosted Ergo services. Please note that it is currently in the BETA stage.
+- [Lumen](https://github.com/from-ufa/lumen) is a live Ergo node and oracle dashboard. Its optional outbound WebSocket bridge exposes allowlisted read-only node data without opening the node REST port; protect the bridge token like a password and verify the operator documentation before deployment.
 - [Ergode](https://github.com/ross-weir/ergode) (ergo-node) is an Ergo node implementation in TypeScript, targeting web and native runtimes.
 - [Ergo Rust Node](rust-node.md) is an experimental Rust implementation that reached mainnet validation to tip during 2026 testing.
 - [Ergo Proxy](ergo-proxy.md) and [Ergo Relay](ergo-relay.md) are lightweight P2P/broadcast tools for relay experiments and transaction broadcast; they do not replace a validating full node.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -139,6 +139,9 @@ source_of_truth:
   - https://sigmanauts.com/mining
   - https://calc.ergominers.com
   - https://github.com/BetterMoneyLabs/braid
+  - https://github.com/a-shannon/ergo-sidechain-bridge
+  - https://github.com/accord-protocol/accord-protocol
+  - https://github.com/from-ufa/lumen
   - https://github.com/fleet-sdk/fleet
   - https://github.com/ergoplatform/ledger-app-ergo
   - https://github.com/arobsn/keystone-ergo-js
@@ -148,7 +151,7 @@ source_of_truth:
 
 # Ergo Development Roadmap & History
 
-This page tracks major Ergo development history and active work as of **July 27, 2026**. It is not a promise of delivery dates. Public repositories, release notes, EIPs, and project pages are the source of truth.
+This page tracks major Ergo development history and active work as of **August 21, 2026**. It is not a promise of delivery dates. Public repositories, release notes, EIPs, and project pages are the source of truth.
 
 Ergo's roadmap is research-led: protocol changes move through papers, EIPs, testnets, client releases, and community review before mainnet activation. Ecosystem projects move at different speeds, so items below are grouped as **completed**, **active**, or **experimental** rather than presented as a single linear release plan.
 
@@ -167,6 +170,12 @@ Ergo's roadmap is research-led: protocol changes move through papers, EIPs, test
 Month buckets summarize roadmap-relevant changes from the latest docs sweep. Use the linked project pages, repositories, and release notes for caveats and source detail.
 
 ### 2026
+
+#### August
+
+- [Ergo node](protocol.md): [v6.0.4](https://github.com/ergoplatform/ergo/releases/tag/v6.0.4) is the latest checked stable release. It includes stricter REST input validation, public-testnet activation corrections, duplicate-mempool protection, block-candidate and extra-index fixes, and recovery when a locally mined block fails validation. [v6.1.4](https://github.com/ergoplatform/ergo/releases/tag/v6.1.4) carries the same changes with RocksDB and is marked as a prerelease.
+- [Sidechains](sidechains.md): a public Ergo-Substrate bridge research alpha now documents deterministic peg construction, lifecycle containment, and audit evidence. It remains blocked on an activated Ergo-verifiable sidechain-finality profile, target-node acceptance, recovery evidence, and independent review.
+- [Lumen](https://github.com/from-ufa/lumen): a live node and oracle dashboard added an optional outbound, allowlisted read-only bridge for viewing a private operator node without exposing its REST port.
 
 #### July
 
@@ -939,9 +948,9 @@ Ergo is developed a by a combination of the [Ergo Foundation](ergo-foundation.md
 - **Protocol and releases:**
   - [AppKit v6.0.0](https://github.com/ergoplatform/ergo-appkit/releases/tag/v6.0.0) released on top of SigmaSDK 6.0.x.
   - [Sigma SDK v6.0.5](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.5) followed the 6.0.0 through 6.0.4 releases.
-  - Ergo node releases moved through `v6.0.2`, `v6.0.2.1`, `v6.0.2.2`, `v6.0.3RC1`, `v6.0.3`, `v6.1.3`, and `v6.0.4RC2`.
+  - Ergo node releases moved through `v6.0.2`, `v6.0.3`, [v6.0.4](https://github.com/ergoplatform/ergo/releases/tag/v6.0.4), and the RocksDB-equivalent [v6.1.4](https://github.com/ergoplatform/ergo/releases/tag/v6.1.4).
   - [Ergo Matrix 6.5.0 RC3](https://github.com/ergoplatform/ergo/releases/tag/v6.5.0-RC3) is the current DevNet build for protocol-breaking change testing.
-  - Node protocol work improved mempool consistency, extension-section validation, missing-parent header handling, and SyncInfoV2 continuation-header handling.
+  - Node protocol work improved mempool consistency, extension-section validation, missing-parent header handling, SyncInfoV2 continuation-header handling, and recovery when a locally mined block fails validation.
   - Matrix DevNet became the main surface for testing protocol-breaking changes before any mainnet proposal.
   - Matrix input-block validation added checks that delivered transaction bodies match the digest committed in proven input-block fields.
 - **Scaling, mining, and validation:**

--- a/docs/uses/sidechains.md
+++ b/docs/uses/sidechains.md
@@ -4,7 +4,7 @@ tags:
   - NiPoPoWs
   - Sigma Chains
 owner: docs
-last_reviewed: 2026-07-27
+last_reviewed: 2026-08-21
 source_repos:
   - repo: BetterMoneyLabs/braid
     branch: master
@@ -16,10 +16,17 @@ source_repos:
       - README.md
       - ROADMAP.md
       - dev-docs/sidechain
+  - repo: a-shannon/ergo-sidechain-bridge
+    branch: main
+    paths:
+      - README.md
+      - docs/public-audit-alpha.md
+      - docs/public-audit-alpha-manifest.json
 source_of_truth:
   - https://github.com/BetterMoneyLabs/braid/blob/master/whitepaper/whitepaper.pdf
   - https://github.com/arkadianet/Aegis-USE
   - https://github.com/arkadianet/Aegis-USE/blob/main/ROADMAP.md
+  - https://github.com/a-shannon/ergo-sidechain-bridge
   - https://github.com/ergoplatform/eips/pull/103
 ia_status: directory
 ---
@@ -34,6 +41,12 @@ Explore recent advancements in sidechain technology through the [ErgoHack VII pr
 ///
 
 Adjacent research also includes [Braid](braid.md), a double merged-mined Bitcoin and Ergo sidechain design. Treat it as research material rather than a deployed Ergo sidechain.
+
+### Ergo-Substrate bridge research alpha
+
+The public [Ergo-Substrate Sidechain Bridge](https://github.com/a-shannon/ergo-sidechain-bridge) is a reference implementation for settling an EVM-compatible Substrate/Frontier sidechain on Ergo. It includes deterministic peg transaction construction, restart and reorganisation handling, explicit transport authorization, AVL-based replay protection, and an audit-first evidence manifest.
+
+This repository is a local research candidate, not a deployed or trustless bridge. Its authenticated path still relies on federated sidechain-finality authority, and its release gate remains blocked on an activated Ergo-verifiable finality profile, exact target-node acceptance, recovery evidence, and independent security review. Do not treat public source or passing local audit checks as mainnet readiness.
 
 ### Aegis-USE research prototype
 


### PR DESCRIPTION
## Summary

- document v6.0.4 mining recovery and current v6.0.4/v6.1.4 release status
- add source-backed coverage for the Ergo-Substrate bridge research alpha, Accord Protocol, and Lumen
- remove the unavailable Aletheia repository reference and regenerate Source Watch inventory

## Triage

- `decentbob/money-from-first-principles` remains conceptual, states that nothing has been built, and provides no Ergo implementation claim; no public docs addition

## Verification

- `.venv/bin/python tools/source_watch.py scan --strict`
- `.venv/bin/python tools/source_watch_inventory.py --check`
- `.venv/bin/python tools/nav_audit.py --strict`
- `.venv/bin/python tools/structure_audit.py --strict`
- `git diff --check`
- `.venv/bin/python -m mkdocs build --site-dir /tmp/ergodocs-site-check`

Closes #514
Closes #515
Closes #516
