### PR TITLE
Integrate August source updates

### DIFF
--- a/docs/contribute/source-watch-inventory.md
+++ b/docs/contribute/source-watch-inventory.md
@@ -21,14 +21,14 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 - Watched repositories: `235`
 - Watched GitHub owners: `102`
 - Watched repo/branch pairs: `241`
-- Watched paths: `509`
+- Watched paths: `508`
 - Release-watched page/repository refs: `13`
 
 ## Coverage Groups
 
 | Group | Owners | Repositories | Pages | Paths |
 | --- | ---: | ---: | ---: | ---: |
-| Core / infrastructure | 5 | 30 | 132 | 189 |
+| Core / infrastructure | 5 | 30 | 132 | 188 |
 | Ecosystem org | 10 | 38 | 24 | 36 |
 | Developer / project | 83 | 163 | 119 | 98 |
 | External standard/vendor | 4 | 4 | 11 | 13 |
@@ -53,7 +53,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 
 | Owner | Group | Repositories | Pages | Paths |
 | --- | --- | ---: | ---: | ---: |
-| [`ergoplatform`](https://github.com/ergoplatform) | Core / infrastructure | 17 | 107 | 150 |
+| [`ergoplatform`](https://github.com/ergoplatform) | Core / infrastructure | 17 | 107 | 149 |
 | [`ScorexFoundation`](https://github.com/ScorexFoundation) | Core / infrastructure | 1 | 24 | 31 |
 | [`rosen-bridge`](https://github.com/rosen-bridge) | Core / infrastructure | 10 | 10 | 6 |
 | [`mwaddip`](https://github.com/mwaddip) | Developer / project | 8 | 9 | 7 |
@@ -160,7 +160,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 
 | Repository | Owner group | Branches | Pages | Paths |
 | --- | --- | --- | ---: | ---: |
-| [`ergoplatform/ergo`](https://github.com/ergoplatform/ergo) | Core / infrastructure | `master`, `testnet60`, `v6.0.3`, `weak-blocks` | 50 | 56 |
+| [`ergoplatform/ergo`](https://github.com/ergoplatform/ergo) | Core / infrastructure | `master`, `testnet60`, `v6.0.3`, `weak-blocks` | 50 | 55 |
 | [`ergoplatform/eips`](https://github.com/ergoplatform/eips) | Core / infrastructure | `eip16`, `master` | 25 | 18 |
 | [`ScorexFoundation/sigmastate-interpreter`](https://github.com/ScorexFoundation/sigmastate-interpreter) | Core / infrastructure | `develop` | 24 | 31 |
 | [`ergoplatform/sigma-rust`](https://github.com/ergoplatform/sigma-rust) | Core / infrastructure | `develop` | 14 | 33 |
@@ -514,7 +514,7 @@ Source Watch checks watched repositories for commits touching declared paths. Gi
 | [`ergoplatform/bounded-vec`](https://github.com/ergoplatform/bounded-vec) | `develop` | `README.md` | `docs/dev/stack/sigma-rust.md` |
 | [`ergoplatform/eips`](https://github.com/ergoplatform/eips) | `eip16` | `eip-0016.md` | `docs/eco/oracles-v2.md`<br>`docs/uses/oracles.md` |
 | [`ergoplatform/eips`](https://github.com/ergoplatform/eips) | `master` | `eip-0001.md`<br>`eip-0003.md`<br>`eip-0004.md`<br>`eip-0005.md`<br>`eip-0006.md`<br>`eip-0012.md`<br>`eip-0015.md`<br>`eip-0017.md`<br>+9 more | `docs/dev/protocol/tx/babel-fees.md`<br>`docs/dev/protocol/tx/babel-fleet.md`<br>`docs/dev/protocol/tx/babel-impl.md`<br>`docs/dev/scs/contracts.md`<br>`docs/dev/scs/ergotree/script-optimisation.md`<br>`docs/dev/stack/headless.md`<br>+17 more |
-| [`ergoplatform/ergo`](https://github.com/ergoplatform/ergo) | `master` | `avldb/src/main/scala/org/ergoplatform/serialization/ErgoSerializer.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/mining/AutolykosPowScheme.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/ADProofs.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/Extension.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionCandidate.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionSerializer.scala`<br>+43 more | `docs/dev/data-model/block-adproofs.md`<br>`docs/dev/data-model/block-header.md`<br>`docs/dev/data-model/block-transactions.md`<br>`docs/dev/data-model/extension-section.md`<br>`docs/dev/data-model/merkle-tree-overview.md`<br>`docs/dev/data-model/structures/interlink-vectors.md`<br>+40 more |
+| [`ergoplatform/ergo`](https://github.com/ergoplatform/ergo) | `master` | `avldb/src/main/scala/org/ergoplatform/serialization/ErgoSerializer.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/mining/AutolykosPowScheme.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/ADProofs.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/BlockTransactions.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/Extension.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionCandidate.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/modifiers/history/extension/ExtensionSerializer.scala`<br>+42 more | `docs/dev/data-model/block-adproofs.md`<br>`docs/dev/data-model/block-header.md`<br>`docs/dev/data-model/block-transactions.md`<br>`docs/dev/data-model/extension-section.md`<br>`docs/dev/data-model/merkle-tree-overview.md`<br>`docs/dev/data-model/structures/interlink-vectors.md`<br>+40 more |
 | [`ergoplatform/ergo`](https://github.com/ergoplatform/ergo) | `testnet60` | `src/main/resources/testnet.conf` | `docs/dev/p2p/network.md`<br>`docs/dev/p2p/p2p-handshake.md` |
 | [`ergoplatform/ergo`](https://github.com/ergoplatform/ergo) | `v6.0.3` | `ergo-core/src/main/scala/org/ergoplatform/settings/ValidationRules.scala`<br>`ergo-core/src/main/scala/org/ergoplatform/validation/ModifierError.scala`<br>`src/main/scala/org/ergoplatform/network/ErgoNodeViewSynchronizer.scala`<br>`src/main/scala/org/ergoplatform/nodeView/mempool/ErgoMemPool.scala`<br>`src/main/scala/org/ergoplatform/nodeView/mempool/OrderedTxPool.scala` | `docs/node/protocol.md`<br>`docs/node/synchronisation.md` |
 | [`ergoplatform/ergo`](https://github.com/ergoplatform/ergo) | `weak-blocks` | `papers/inputblocks/main.pdf` | `docs/uses/sidechains/subblocks.md` |

--- a/docs/dev/scs/sigmastate-interpreter.md
+++ b/docs/dev/scs/sigmastate-interpreter.md
@@ -6,7 +6,7 @@ tags:
   - Compiler
   - Interpreter
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-25
 source_repos:
   - repo: ergoplatform/sigmastate-interpreter
     branch: develop
@@ -22,8 +22,8 @@ source_repos:
     paths:
       - ergo-wallet
 source_of_truth:
-  - https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.5
-  - https://repo1.maven.org/maven2/org/scorexfoundation/sigma-state_2.12/6.0.5/sigma-state_2.12-6.0.5.pom
+  - https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.6
+  - https://repo1.maven.org/maven2/org/scorexfoundation/sigma-state_2.12/6.0.6/sigma-state_2.12-6.0.6.pom
   - https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.2
   - https://github.com/ergoplatform/sigmastate-interpreter/pull/1076
   - https://github.com/ergoplatform/sigmastate-interpreter/tree/develop/README.md
@@ -44,6 +44,8 @@ This library is integral to the operation of the [Ergo Node](https://github.com/
 
 ## Recent updates
 
+- `Aug 21`: [Sigma SDK v6.0.6](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.6) was released and published to Maven Central.
+- v6.0.6 adds drift-check golden tests for specification generators, Bitcoin transaction-parsing examples including amount-bound outputs, checked compiler handling for non-OOM `VirtualMachineError` failures during typechecking, and better selector errors and source positions.
 - `Jun 24`: [Sigma SDK v6.0.5](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.5) was released.
 - v6.0.5 added regression coverage for `ByIndex` upcasts with non-`Int` indexes, serializer benchmarks, cross-platform `Exponentiate` equivalence checks, subproject module names, TaggedVariable wire-format pinning with Scala-type deprecation, and rejection of negative-id variables in the `ContextExtension` deserializer.
 - `May 28`: [Sigma SDK v6.0.4](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.4) was released.
@@ -91,7 +93,7 @@ While the sigmastate-interpreter library provides the low-level primitives neces
 To start using the sigmastate-interpreter in your Scala project, add the following dependency to your SBT configuration:
 
 ```scala
-libraryDependencies += "org.scorexfoundation" %% "sigma-state" % "6.0.5"
+libraryDependencies += "org.scorexfoundation" %% "sigma-state" % "6.0.6"
 ```
 
 For more advanced usage and direct interaction with the ErgoTree and Sigma protocols, refer to the detailed [Sigma Language documentation](sigma-lang.md).

--- a/docs/eco/bottube.md
+++ b/docs/eco/bottube.md
@@ -7,7 +7,7 @@ tags:
   - AI
   - video
 owner: docs
-last_reviewed: 2026-08-20
+last_reviewed: 2026-08-25
 source_repos:
   - repo: Scottcjn/bottube
     branch: main
@@ -52,6 +52,8 @@ The Ergo bridge blueprint covers:
 - ERG-to-RTC exchange-rate handling for the platform integration.
 - request-body validation for deposit and withdrawal flows, returning deterministic `400` responses for malformed JSON fields before chain checks, queueing, or balance-debit logic.
 - malformed Ergo Explorer history limits and invalid admin-completion JSON are handled without crashing the bridge blueprint.
+- ERG deposits write the deposit record, RTC balance credit, and `earnings.reason` record in one database transaction. If crediting fails, the deposit record rolls back so the transaction ID remains retryable instead of becoming permanently claimed.
+- RTC withdrawals use a balance-guarded debit update, preventing concurrent requests from taking the agent balance below zero.
 
 Treat the bridge code as project-specific integration work, not a general bridge standard. Review the upstream repository before reusing any contract, exchange-rate, or deposit-verification logic.
 

--- a/docs/eco/emerging-projects.md
+++ b/docs/eco/emerging-projects.md
@@ -7,7 +7,7 @@ tags:
   - tooling
   - community
 owner: docs
-last_reviewed: 2026-08-20
+last_reviewed: 2026-08-25
 ia_status: directory
 source_repos:
   - repo: Scottcjn/bottube
@@ -97,7 +97,7 @@ These projects are recent ecosystem additions verified against public repositori
 
 | Dedicated page | What it is | Status | Related surface |
 | --- | --- | --- | --- |
-| [BoTTube](bottube.md) | AI-native video platform with an Ergo bridge blueprint for deposit verification, request validation, P2PK address handling, and recent BCOS/error-handling work. | Emerging | Applications and utilities. |
+| [BoTTube](bottube.md) | AI-native video platform with an Ergo bridge blueprint for deposit verification, atomic deposit credits, balance-guarded withdrawals, request validation, and P2PK address handling. | Emerging | Applications and utilities. |
 | [Ergo Agent SDK](ergo-agent-sdk.md) | Python SDK for giving autonomous agents controlled access to Ergo and its DeFi ecosystem. | Developer-facing | Developer frameworks. |
 | [Ergo Proxy](ergo-proxy.md) | Lightweight Ergo P2P relay proxy for forwarding peer messages without holding blockchain state. | Developer-facing | Node operations and P2P tooling. |
 | [Ergo Relay](ergo-relay.md) | Minimal transaction signing and P2P relay service. | Developer-facing | Node operations and transaction broadcast tooling. |
@@ -122,7 +122,7 @@ These related projects already have a page or a suitable umbrella page:
 - [Rosen Bridge](rosen.md), including guard, watcher, scanner, and health-check tooling
 - [Dexy](dexy.md) and [Stablecoins](stablecoins.md)
 - [Braid](braid.md), a Bitcoin and Ergo double merged-mined sidechain research project
-- [CodeUtxo](codeutxo.md), Aletheia Protocol, FintelligenceAI, and the AI Project Starter Kit are covered in the [AI](ai.md) and [ErgoHack](ergohack.md) pages
+- [CodeUtxo](codeutxo.md), FintelligenceAI, and the AI Project Starter Kit are covered in the [AI](ai.md) and [ErgoHack](ergohack.md) pages
 
 ## Not Added
 

--- a/docs/eco/lithos.md
+++ b/docs/eco/lithos.md
@@ -7,7 +7,7 @@ tags:
   - dApp
   - dApp-InDev
 owner: docs
-last_reviewed: 2026-07-02
+last_reviewed: 2026-08-25
 source_repos:
   - repo: Lithos-Protocol/Lithos-Client
     branch: master
@@ -18,6 +18,7 @@ source_repos:
 source_of_truth:
   - https://github.com/Lithos-Protocol/Lithos-Client
   - https://github.com/Lithos-Protocol/LitePaper
+  - https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v5.0.0-test
   - https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v4.2.0-test
   - https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v4.1.0-test
   - https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v1.1-test
@@ -47,6 +48,8 @@ Earlier SNISP/NISP research is now treated as Lithos background rather than a se
 The first public testnet releases arrived in November 2025. [`v1.0-test`](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v1.0-test) introduced the testnet client package, and [`v1.1-test`](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v1.1-test) followed with stability fixes, Stratum error-handling changes, setup simplification, refactoring, and logging changes.
 
 For testnet use, the client needs node API access and a testnet wallet keystore so it can sign and generate transactions. The upstream testnet guide warns users to create a new testnet-only secret key rather than reusing a mainnet wallet.
+
+[v5.0.0-test](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v5.0.0-test) is the current testnet client. It requires an indexed Ergo node running v6.0.4 or later and introduces substantial configuration changes. The release adds the new emissions and collateral flow, stronger wallet UTXO tracking and reservations, MinerDictionary synchronization fixes, LithosDex APIs and local web UI, block-package and fraud-proof-stub transaction support, candidate-builder options, and Stratum concurrency improvements. Existing testnet operators should rebuild their overrides against the current README and `application.conf` rather than reusing an older configuration unchanged.
 
 [v4.2.0-test](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v4.2.0-test) changes mempool synchronization so subscribers are notified when mempool updates occur rather than receiving full mempool contents. It also moves major transaction code into dedicated transaction actors, represents future transactions as transaction stubs, and fixes rollup synchronization around chained payout-contract rollups.
 

--- a/docs/eco/rosen/guard.md
+++ b/docs/eco/rosen/guard.md
@@ -5,7 +5,7 @@ tags:
   - Deploy
   - Operations
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-25
 source_repos:
   - repo: rosen-bridge/operation
     branch: dev
@@ -45,6 +45,15 @@ docker compose create
 ```
 
 Before running guard service, participate in Rosen key generation ceremony using the keygen service docs from Rosen.
+
+If you enable the optional Alloy or Prometheus Agent containers, make their configuration trees and entrypoint executable before startup:
+
+```shell
+chmod -R ao+rX ./alloy ./prometheus-agent
+chmod o+x ./prometheus-agent/entrypoint.sh
+```
+
+Current Rosen deployment docs use symbolic permissions so these commands still work under restrictive operator umasks such as `007`.
 
 ## Required Environment
 

--- a/docs/eco/rosen/watcher.md
+++ b/docs/eco/rosen/watcher.md
@@ -9,7 +9,7 @@ tags:
   - Cross-chain
   - Oracle
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-25
 source_repos:
   - repo: rosen-bridge/operation
     branch: dev
@@ -171,6 +171,15 @@ The watcher Compose override includes optional monitoring agents:
 - `COMPOSE_PROFILES=logger,monitoring` enables both profiles.
 
 Set `IS_SAME_HOST=true` only when the Grafana, Prometheus, and Loki stack is on the watcher host; deploy that stack first so its external networks exist. For a remote stack, set `IS_SAME_HOST=false` and configure the remote URLs and optional basic-auth values in `.env.logger` and `.env.monitoring`. The logger profile also requires JSON file logging with `createSymlink: true` so Alloy can tail `current.log`.
+
+Before starting either monitoring profile, apply the current upstream permissions:
+
+```shell
+chmod -R ao+rX ./alloy ./prometheus-agent
+chmod o+x ./prometheus-agent/entrypoint.sh
+```
+
+The symbolic modes remain effective when the host uses a restrictive umask such as `007`.
 
 ## Watcher FAQs
 

--- a/docs/eco/rust-chain.md
+++ b/docs/eco/rust-chain.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-08-20
+last_reviewed: 2026-08-25
 source_repos:
   - repo: Scottcjn/Rustchain
     branch: main

--- a/docs/eco/vanity-gpu.md
+++ b/docs/eco/vanity-gpu.md
@@ -4,7 +4,7 @@ tags:
   - Mining
   - Tooling
 owner: docs
-last_reviewed: 2026-05-30
+last_reviewed: 2026-08-25
 source_repos:
   - repo: arkadianet/erg-vanity-gpu
     branch: main
@@ -12,19 +12,22 @@ source_repos:
       - README.md
 source_of_truth:
   - https://github.com/arkadianet/erg-vanity-gpu
+  - https://github.com/arkadianet/erg-vanity-gpu/releases/tag/v0.4.0
 ---
 
 # Vanity GPU
 
-[erg-vanity-gpu](https://github.com/arkadianet/erg-vanity-gpu) is a GPU-accelerated Ergo vanity address generator using OpenCL. It supports multi-GPU search, multiple patterns, optional case-insensitive matching, BIP44 derivation at `m/44'/429'/0'/0/{index}`, benchmark mode, and device selection.
+[erg-vanity-gpu](https://github.com/arkadianet/erg-vanity-gpu) is a GPU-accelerated Ergo vanity address generator. Prefix searches use OpenCL by default, with an optional NVIDIA CUDA backend on Linux; suffix and contains searches remain CPU-only. It supports a desktop GUI, CPU fallback, multi-GPU search, multiple patterns, optional case-insensitive matching, BIP44 derivation at `m/44'/429'/0'/0/{index}`, estimates, benchmarks, and device selection.
 
 The upstream README marks the project as early-development software. It warns that the cryptographic implementations were written from scratch and should not be trusted for significant funds unless the generated mnemonic and address are independently verified with trusted wallet software.
 
 ## GPU Vanity Address Generator
 
-Early benchmarks reported roughly `790k/sec` on `7x 3060 Ti`, roughly `1.3M/sec` across all GPUs, and later about `320k addresses/sec` on an RTX 3080 Ti. The build notes also called out nightly Rust requirements for the OpenCL path.
+[v0.4.0](https://github.com/arkadianet/erg-vanity-gpu/releases/tag/v0.4.0) adds larger default GPU batches and the optional CUDA backend for Linux builds on NVIDIA `sm_75+` GPUs. Set `ERG_BACKEND=cuda` to opt in; OpenCL remains the default and the same kernels are used by both paths.
 
-Current prerequisites are Rust 2021 stable plus OpenCL runtime/development headers. The CLI can list devices, search specific GPUs or all GPUs, stop after a fixed number of matches, run for a duration, and benchmark the GPU pipeline.
+Current prerequisites for source builds are Rust 2021 stable plus OpenCL runtime/development headers. The CLI can list devices, search specific GPUs or all GPUs, stop after a fixed number of matches, run for a duration, estimate difficulty, and benchmark the GPU pipeline. It rejects impossible mainnet P2PK prefixes before searching.
+
+The upstream RTX 3090 measurements range from roughly `563k` addresses/second at the default `--index 1` to `36.9M` addresses/second at `--index 500`, but higher index counts trade wallet discoverability for throughput. Most wallets stop after roughly 20 unused BIP44 slots, so restore may not find a result at a high slot without manual scanning. Keep the default unless you understand that tradeoff, and treat all benchmark figures as hardware- and driver-specific.
 
 ## Related Pages
 

--- a/docs/node/conf/conf-node.md
+++ b/docs/node/conf/conf-node.md
@@ -1,6 +1,6 @@
 ---
 owner: docs
-last_reviewed: 2026-07-10
+last_reviewed: 2026-08-25
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -10,6 +10,8 @@ source_repos:
       - src/main/resources/application.conf
 source_of_truth:
   - https://github.com/ergoplatform/ergo/tree/master/src/main/scala/org/ergoplatform/nodeView/history/extra/ExtraIndexer.scala
+  - https://github.com/ergoplatform/ergo/pull/2442
+  - https://github.com/ergoplatform/ergo/commit/cdf3061d25f9343fd45bd7a6c2be124158ff314a
   - https://github.com/ergoplatform/ergo/tree/master/src/main/scala/org/ergoplatform/nodeView/history/extra/IndexedContractTemplate.scala
   - https://github.com/ergoplatform/ergo/tree/master/src/main/resources/application.conf
 ---
@@ -40,6 +42,8 @@ Contract-template indexing hashes `ErgoTree.template` under the current version 
 Enable this for nodes serving dApps, explorers, Rosen watcher health checks, and any workload that needs `/blockchain/...` indexed routes. Leave it disabled for a simple validating node where lower disk and indexing overhead matter more than query features.
 
 After enabling it, monitor [indexed height](indexed-node.md) separately from node sync height.
+
+Current extra-index state tracks the indexed header ID as well as height. During a reorganisation, the indexer checks parent continuity, defers blocks that do not extend its recorded tip, rolls indexed data back to the branch point, and then resumes catch-up. A later full-block event also restarts catch-up if it was deferred, preventing the indexed height from remaining stalled after a temporary fork. Continue monitoring indexed height after reorgs; API availability alone does not prove the index has caught up.
 
 ## P2P Local Access
 

--- a/docs/node/install/pi.md
+++ b/docs/node/install/pi.md
@@ -1,13 +1,13 @@
 ---
 owner: docs
-last_reviewed: 2026-07-10
+last_reviewed: 2026-08-25
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
     paths:
-      - src/main/resources
+      - src/main/resources/application.conf
 source_of_truth:
-  - https://github.com/ergoplatform/ergo/tree/master/src/main/resources
+  - https://github.com/ergoplatform/ergo/tree/master/src/main/resources/application.conf
 ---
 
 # ErgoPi
@@ -97,7 +97,7 @@ scorex {
 }
 ```
 
-There are several configuration options that be tweaked in your `ergo.conf` file. The [resource directory on the main GitHub repository](https://github.com/ergoplatform/ergo/tree/master/src/main/resources) has examples of all available options.
+There are several configuration options that can be tweaked in your `ergo.conf` file. The upstream [`application.conf`](https://github.com/ergoplatform/ergo/blob/master/src/main/resources/application.conf) documents the available defaults.
 
 Current upstream configs use `allowLocal` for local, site-local, and loopback P2P access. Older notes may still refer to `localOnly`; treat that as the old name when comparing guides against current `application.conf`.
 

--- a/docs/node/operations/monitoring.md
+++ b/docs/node/operations/monitoring.md
@@ -5,7 +5,7 @@ tags:
   - Monitoring
   - Alerts
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-25
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -59,5 +59,14 @@ Monitor sync, index lag, API health, and host resources separately.
 Current Rosen watcher deployment supports separate `logger` and `monitoring` Compose profiles. The logger path uses Alloy and Loki; the metrics path uses Prometheus Agent, Node Exporter, and cAdvisor, with Grafana and Alertmanager in the observability stack.
 
 Use `COMPOSE_PROFILES=logger`, `monitoring`, or `logger,monitoring`. Set `IS_SAME_HOST=true` only when the observability stack shares the watcher host and its external networks already exist. For a remote stack, use `IS_SAME_HOST=false` and set remote-write URLs and basic-auth credentials in the monitoring environment files. Keep those credentials out of source control.
+
+Before starting the optional agents, make the configuration trees readable/traversable and the Prometheus Agent entrypoint executable:
+
+```shell
+chmod -R ao+rX ./alloy ./prometheus-agent
+chmod o+x ./prometheus-agent/entrypoint.sh
+```
+
+Use these symbolic modes rather than fixed numeric permissions; they remain effective under restrictive umasks such as `007`.
 
 cAdvisor filesystem and disk-I/O panels may show no data on cgroup v2 hosts; Rosen's source guide calls out full `container_fs_*` coverage as a cgroup v1 limitation.

--- a/docs/node/swagger.md
+++ b/docs/node/swagger.md
@@ -7,7 +7,7 @@ tags:
   - UI
   - RPC Endpoints
 owner: docs
-last_reviewed: 2026-07-26
+last_reviewed: 2026-08-25
 source_repos:
   - repo: ergoplatform/ergo
     branch: master
@@ -16,7 +16,8 @@ source_repos:
 source_of_truth:
   - https://github.com/ergoplatform/ergo/tree/master/src/main/resources/api/openapi.yaml
   - https://github.com/ergoplatform/ergo/releases/tag/v6.0.1
-  - https://github.com/ergoplatform/ergo/releases/tag/v6.0.4RC2
+  - https://github.com/ergoplatform/ergo/releases/tag/v6.0.4
+  - https://github.com/ergoplatform/ergo/pull/2459
   - https://github.com/ergoplatform/ergo/pull/2235
   - https://github.com/ergoplatform/ergo/pull/2222
 ---
@@ -86,7 +87,9 @@ Current OpenAPI groups are useful for different operator jobs:
 
 Indexed history routes require `ergo.node.extraIndex = true`. Wallet and node-control routes require the plain API key in the `api_key` header; the config stores only the Blake2b hash.
 
-Recent 6.0.4 prerelease handling rejects invalid API inputs earlier: out-of-range `/blocks/chainSlice` requests, invalid scan IDs, wrong-length modifier, box, or token IDs, and malformed secret-proof-hint hex return errors instead of reaching deeper node logic. Public mining and script routes remain public even if older generated OpenAPI material showed incorrect security annotations. RC2 also fixes the `CommitmentWithSecret` schema indentation in `openapi.yaml`.
+Node v6.0.4 rejects invalid API inputs earlier: out-of-range `/blocks/chainSlice` requests, invalid scan IDs, wrong-length modifier, box, or token IDs, and malformed secret-proof-hint hex return errors instead of reaching deeper node logic. Public mining and script routes remain public even if older generated OpenAPI material showed incorrect security annotations. The release also fixes the `CommitmentWithSecret` schema indentation in `openapi.yaml`.
+
+The `PopowHeader` schema now matches the node encoder and decoder: `header`, `interlinks`, and `interlinksProof` are required. `interlinksProof` is a `BatchMerkleProof` containing indexed leaf digests and proof nodes with their side. Clients generated from an older OpenAPI file may omit this required proof field and should refresh against the v6.0.4 schema.
 
 ### Blockchain Box Queries
 

--- a/docs/node/wallet-setup.md
+++ b/docs/node/wallet-setup.md
@@ -8,7 +8,7 @@ tags:
   - BIP32
   - BIP39
 owner: docs
-last_reviewed: 2026-05-26
+last_reviewed: 2026-08-25
 source_repos:
   - repo: ergoplatform/ergo-wallet
     branch: master

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,7 +2,7 @@
 tags:
   - Roadmap
 owner: docs
-last_reviewed: 2026-08-20
+last_reviewed: 2026-08-25
 source_repos:
   - repo: ergoplatform/eips
     branch: master
@@ -125,7 +125,7 @@ source_of_truth:
   - https://github.com/mwaddip/ergots
   - https://github.com/odiseusme/matrix-pulse
   - https://github.com/decentbob/ergo-marketplace
-  - https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v4.2.0-test
+  - https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v5.0.0-test
   - https://github.com/rosen-bridge
   - https://github.com/ChainCashLabs/chaincash
   - https://github.com/StabilityNexus/Gluon-Ergo-UI
@@ -174,6 +174,8 @@ Month buckets summarize roadmap-relevant changes from the latest docs sweep. Use
 #### August
 
 - [Ergo node](protocol.md): [v6.0.4](https://github.com/ergoplatform/ergo/releases/tag/v6.0.4) is the latest checked stable release. It includes stricter REST input validation, public-testnet activation corrections, duplicate-mempool protection, block-candidate and extra-index fixes, and recovery when a locally mined block fails validation. [v6.1.4](https://github.com/ergoplatform/ergo/releases/tag/v6.1.4) carries the same changes with RocksDB and is marked as a prerelease.
+- [Sigma SDK](sigmastate-interpreter.md): [v6.0.6](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.6) adds specification-generator drift checks, Bitcoin transaction-parsing examples, checked handling for non-OOM VM errors during typechecking, and better selector diagnostics.
+- [Lithos](lithos.md): [v5.0.0-test](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v5.0.0-test) requires an indexed Ergo node v6.0.4 or later and updates emissions, collateral, wallet reservations, MinerDictionary synchronization, LithosDex, transaction packaging, Stratum, and the local web UI. It remains a testnet release.
 - [Sidechains](sidechains.md): a public Ergo-Substrate bridge research alpha now documents deterministic peg construction, lifecycle containment, and audit evidence. It remains blocked on an activated Ergo-verifiable sidechain-finality profile, target-node acceptance, recovery evidence, and independent review.
 - [Lumen](https://github.com/from-ufa/lumen): a live node and oracle dashboard added an optional outbound, allowlisted read-only bridge for viewing a private operator node without exposing its REST port.
 
@@ -243,7 +245,7 @@ This is the clearest short-form view of what is in the pipeline. Items are group
 | Rust / TypeScript stack | **Active implementation research**: `sigma-rust`, `mwaddip/ergo-node-rust`, `arkadianet/ergo`, `ergots`, and SANTA runners are differential-testing surfaces, not replacements for the JVM consensus authority unless upstream marks a path stable. |
 | Scaling | **Research / testnet**: sub-blocks, Braid / merged-mined sidechain design, NiPoPoW bootstrapping, pruned operation, and devnet testing remain active tracks. |
 | Interoperability | **Live + expanding**: Rosen Bridge is live across Ergo, Cardano, BTC, EVM/BSC, and DOGE, with more chain work and Runes-related support in progress. |
-| Mining decentralization | **Testnet**: Lithos has moved through multiple 2026 testnet releases, reaching `v4.2.0-test`. |
+| Mining decentralization | **Testnet**: Lithos has moved through multiple 2026 testnet releases, reaching `v5.0.0-test`. |
 | DeFi and monetary systems | **Mixed**: Spectrum, SigmaUSD, Dexy, Gluon Gold, SigmaFi, Duckpools, Machina, Etcha, ChainCash/Basis, Ergo Marketplace, and related tools cover live, alpha, and prototype stages. |
 | Data and observability | **Active tooling**: eBiome, Matrix Pulse, Ergo Mempool Watcher, explorers, and knowledge-base tooling expand monitoring, analytics, forensics, and project-context surfaces. |
 | Governance and funding | **Decentralizing**: the Ergo Foundation has narrowed its role; [Sigmanauts](sigmanauts.md), [GitCircles](gitcircles.md), and independent teams now manage more ecosystem functions. See [Ergo Foundation Treasury](ef-treasury.md), [EF Votes](ef-votes.md), and [EF Future](ef-future.md). |
@@ -283,10 +285,10 @@ These timeline items matter for continuity. Treat them as current work only when
 ### 2026: Protocol, DevNet, and Application Tooling
 
 - [x] [AppKit v6.0.0](https://github.com/ergoplatform/ergo-appkit/releases/tag/v6.0.0) released on top of SigmaSDK 6.0.x, including EIP-50 / Sigma 6.0 alignment work and prover-evaluated tests.
-- [x] [Sigma SDK v6.0.5](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.5) released after the 6.0.0 through 6.0.4 releases, adding regression coverage and serialization/deserialization hardening.
+- [x] [Sigma SDK v6.0.6](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.6) released after the 6.0.0 through 6.0.5 releases, adding generator drift checks, Bitcoin parsing examples, compiler error handling, and selector diagnostics.
 - [x] Ergo node releases moved through `v6.0.2`, `v6.0.3`, [v6.0.4](https://github.com/ergoplatform/ergo/releases/tag/v6.0.4), and the RocksDB-equivalent [v6.1.4](https://github.com/ergoplatform/ergo/releases/tag/v6.1.4); [Ergo Matrix 6.5.0 RC3](https://github.com/ergoplatform/ergo/releases/tag/v6.5.0-RC3) remains the special DevNet build for protocol-breaking-change testing and p2p-layer fixes.
 - [x] Node protocol work improved mempool consistency, extension-section validation, missing-parent header handling, SyncInfoV2 continuation-header handling, and Matrix input-block transaction-body digest checks. See [Ergo Node Protocol](protocol.md), [Synchronisation](synchronisation.md), and [Sub-blocks](subblocks.md).
-- [x] [Lithos](lithos.md) moved through `v3.0.0-test`, `v3.1.0-test`, `v4.0.0-test`, `v4.1.0-test`, and [`v4.2.0-test`](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v4.2.0-test), with work on mempool tracking, Stratum behavior, transaction scheduling, and rollup evaluation.
+- [x] [Lithos](lithos.md) moved through the 3.x and 4.x testnet lines to [`v5.0.0-test`](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v5.0.0-test), adding an indexed-node requirement and reworking emissions, collateral, wallet reservations, LithosDex, transaction packaging, Stratum, and the local UI.
 - [x] [ChainCash](chaincash.md) and Basis advanced through reserve-contract rework, tracker persistence, on-chain state-update testing, note redemption, server/API work, and presentation material for 2026 research events.
 - [x] [Gluon Gold](gluon.md) is live at [gluon.gold](https://gluon.gold/) with a public Ergo UI repository.
 - [x] [Machina Finance](machina-finance.md) published an alpha orders SDK with grid and limit-order transaction builders.
@@ -359,7 +361,7 @@ The emphasis in 2026 is validation and application work on top of the 6.x stack,
 | --- | --- | --- |
 | [Storage rent](storage-rent.md) and pruning | Live economic/state-management primitives. | Operator guidance, explorer support, and wallet UX. |
 | NiPoPoWs / light clients | Core design primitive, with bootstrapping and proof-serving work continuing. | Node, Rust, and SDK support for practical light-client flows. |
-| [Lithos](lithos.md) | Testnet client releases reached `v4.2.0-test`. | Mainnet-readiness notes, Stratum/miner docs, collateral flows, and risk disclosures. |
+| [Lithos](lithos.md) | Testnet client releases reached `v5.0.0-test`. | Mainnet-readiness notes, Stratum/miner docs, collateral flows, and risk disclosures. |
 | Sub-blocks / Layer 2 | Research and development track. | Devnet evidence and clear security assumptions. |
 | Matrix observability | [Matrix Pulse](matrix-pulse.md) provides local Matrix input-block monitoring for arrivals, applies, queues, forks, and status headers. | Maintained releases, operator docs, and whether Matrix tooling becomes part of standard devnet observability. |
 | FIMOs and miner utilities | Fair Initial Mining Offering concepts and miner tooling remain ecosystem-level research / utility work; Sigmanauts added public calculator and operator-tooling plans. | Concrete contracts, mining-pool support, and user-facing risk documentation. |
@@ -947,14 +949,14 @@ Ergo is developed a by a combination of the [Ergo Foundation](ergo-foundation.md
 
 - **Protocol and releases:**
   - [AppKit v6.0.0](https://github.com/ergoplatform/ergo-appkit/releases/tag/v6.0.0) released on top of SigmaSDK 6.0.x.
-  - [Sigma SDK v6.0.5](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.5) followed the 6.0.0 through 6.0.4 releases.
+  - [Sigma SDK v6.0.6](https://github.com/ergoplatform/sigmastate-interpreter/releases/tag/v6.0.6) followed the 6.0.0 through 6.0.5 releases.
   - Ergo node releases moved through `v6.0.2`, `v6.0.3`, [v6.0.4](https://github.com/ergoplatform/ergo/releases/tag/v6.0.4), and the RocksDB-equivalent [v6.1.4](https://github.com/ergoplatform/ergo/releases/tag/v6.1.4).
   - [Ergo Matrix 6.5.0 RC3](https://github.com/ergoplatform/ergo/releases/tag/v6.5.0-RC3) is the current DevNet build for protocol-breaking change testing.
   - Node protocol work improved mempool consistency, extension-section validation, missing-parent header handling, SyncInfoV2 continuation-header handling, and recovery when a locally mined block fails validation.
   - Matrix DevNet became the main surface for testing protocol-breaking changes before any mainnet proposal.
   - Matrix input-block validation added checks that delivered transaction bodies match the digest committed in proven input-block fields.
 - **Scaling, mining, and validation:**
-  - [Lithos](lithos.md) testnet releases reached [`v4.2.0-test`](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v4.2.0-test), with work on mempool tracking, Stratum behavior, transaction scheduling, and rollup evaluation.
+  - [Lithos](lithos.md) testnet releases reached [`v5.0.0-test`](https://github.com/Lithos-Protocol/Lithos-Client/releases/tag/v5.0.0-test), with an indexed-node requirement and changes across emissions, collateral, wallet reservations, LithosDex, transaction packaging, Stratum, and the local UI.
   - [Rust node](rust-node.md) releases reached the 0.7.x line.
   - SANTA added shared conformance vectors and runners for cross-implementation testing.
   - Rust node, SANTA, `sigma-rust`, and [ergots](ergots.md) continued to expose consensus and evaluation edge cases for review against the JVM reference stack.


### PR DESCRIPTION
## Summary

- document SigmaSDK 6.0.6, Lithos 5.0.0-test, vanity GPU 0.4.0, and current roadmap status
- cover BoTTube atomic accounting, Ergo extra-index reorg recovery, PoPoW OpenAPI proof shape, and Rosen monitoring permissions
- narrow the Raspberry Pi source watch to `application.conf`, refresh reviewed pages, and regenerate the inventory

## Triage

- RustChain change was framing already covered by the page
- Raspberry Pi OpenAPI changes were unrelated; the watch path is now narrowed
- wallet scan-ID validation is already covered on the API page and does not change wallet setup

## Verification

- `.venv/bin/python tools/source_watch.py scan --strict`
- `.venv/bin/python tools/source_watch_inventory.py --check`
- `.venv/bin/python tools/nav_audit.py --strict`
- `.venv/bin/python tools/structure_audit.py --strict`
- `git diff --check`
- `.venv/bin/python -m mkdocs build --site-dir /tmp/ergodocs-site-check`

Closes #518
Closes #519
Closes #520
Closes #521
Closes #522
Closes #523
Closes #524
Closes #525
Closes #526
Closes #527
Closes #528
Closes #529
Closes #530
Closes #531
